### PR TITLE
修复回复文本消息时构造方法参数错误

### DIFF
--- a/src/Kernel/Messages/Text.php
+++ b/src/Kernel/Messages/Text.php
@@ -37,7 +37,7 @@ class Text extends Message
      *
      * @param string $content
      */
-    public function __construct(string $content)
+    public function __construct(string $content = '')
     {
         parent::__construct(compact('content'));
     }


### PR DESCRIPTION
[文档](https://www.easywechat.com/docs/5.x/official-account/messages) 中有三种方式可以回复文本消息，但第二种和第三种无法使用，因为 `Text` 类的构造方法的参数时必须填写的。

```
// or
$text = new Text();
$text->content = '您好！overtrue。';

// or
$text = new Text();
$text->setAttribute('content', '您好！overtrue。');
```