### PR TITLE
[feature]【企业微信】新增通讯录(互联企业)

### DIFF
--- a/src/Work/User/LinkedCorpClient.php
+++ b/src/Work/User/LinkedCorpClient.php
@@ -30,7 +30,7 @@ class LinkedCorpClient extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function getAgentPerms()
+    public function getAgentPermissions()
     {
         return $this->httpPostJson('cgi-bin/linkedcorp/agent/get_perm_list');
     }
@@ -47,7 +47,7 @@ class LinkedCorpClient extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function get(string $userId)
+    public function getUser(string $userId)
     {
         $params = [
             'userid' => $userId
@@ -69,7 +69,7 @@ class LinkedCorpClient extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function userSimples(string $departmentId, bool $fetchChild = true)
+    public function getUsers(string $departmentId, bool $fetchChild = true)
     {
         $params = [
             'department_id' => $departmentId,
@@ -92,7 +92,7 @@ class LinkedCorpClient extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function users(string $departmentId, bool $fetchChild = true)
+    public function getDetailedUsers(string $departmentId, bool $fetchChild = true)
     {
         $params = [
             'department_id' => $departmentId,
@@ -114,7 +114,7 @@ class LinkedCorpClient extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function departments(string $departmentId)
+    public function getDepartments(string $departmentId)
     {
         $params = [
             'department_id' => $departmentId,

--- a/src/Work/User/LinkedCorpClient.php
+++ b/src/Work/User/LinkedCorpClient.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\Work\User;
+
+use EasyWeChat\Kernel\BaseClient;
+
+/**
+ * Class Client.
+ *
+ * @author 读心印 <aa24615@qq.com>
+ */
+class LinkedCorpClient extends BaseClient
+{
+    /**
+     * 获取应用的可见范围.
+     *
+     * @see https://open.work.weixin.qq.com/api/doc/90000/90135/93172
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getAgentPerms()
+    {
+        return $this->httpPostJson('cgi-bin/linkedcorp/agent/get_perm_list');
+    }
+
+    /**
+     * 获取互联企业成员详细信息.
+     *
+     * @see https://open.work.weixin.qq.com/api/doc/90000/90135/93171
+     *
+     * @param string $userId
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function get(string $userId)
+    {
+        $params = [
+            'userid' => $userId
+        ];
+
+        return $this->httpPostJson('cgi-bin/linkedcorp/user/get', $params);
+    }
+
+    /**
+     * 获取互联企业部门成员.
+     *
+     * @see https://open.work.weixin.qq.com/api/doc/90000/90135/93168
+     *
+     * @param string $departmentId
+     * @param bool $fetchChild
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function userSimples(string $departmentId, bool $fetchChild = true)
+    {
+        $params = [
+            'department_id' => $departmentId,
+            'fetch_child' => $fetchChild
+        ];
+
+        return $this->httpPostJson('cgi-bin/linkedcorp/user/simplelist', $params);
+    }
+
+    /**
+     * 获取互联企业部门成员详情.
+     *
+     * @see https://open.work.weixin.qq.com/api/doc/90000/90135/93169
+     *
+     * @param string $departmentId
+     * @param bool $fetchChild
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function users(string $departmentId, bool $fetchChild = true)
+    {
+        $params = [
+            'department_id' => $departmentId,
+            'fetch_child' => $fetchChild
+        ];
+
+        return $this->httpPostJson('cgi-bin/linkedcorp/user/list', $params);
+    }
+
+    /**
+     * 获取互联企业部门列表.
+     *
+     * @see https://open.work.weixin.qq.com/api/doc/90000/90135/93170
+     *
+     * @param string $departmentId
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function departments(string $departmentId)
+    {
+        $params = [
+            'department_id' => $departmentId,
+        ];
+
+        return $this->httpPostJson('cgi-bin/linkedcorp/department/list', $params);
+    }
+}

--- a/src/Work/User/ServiceProvider.php
+++ b/src/Work/User/ServiceProvider.php
@@ -33,5 +33,9 @@ class ServiceProvider implements ServiceProviderInterface
         $app['tag'] = function ($app) {
             return new TagClient($app);
         };
+
+        $app['linked_corp'] = function ($app) {
+            return new LinkedCorpClient($app);
+        };
     }
 }

--- a/tests/Work/User/LinkedCorpClientTest.php
+++ b/tests/Work/User/LinkedCorpClientTest.php
@@ -16,16 +16,16 @@ use EasyWeChat\Work\User\LinkedCorpClient;
 
 class LinkedCorpClientTest extends TestCase
 {
-    public function testGetAgentPerms()
+    public function testGetAgentPermissions()
     {
         $client = $this->mockApiClient(LinkedCorpClient::class);
 
         $client->expects()->httpPostJson('cgi-bin/linkedcorp/agent/get_perm_list')->andReturn('mock-result');
 
-        $this->assertSame('mock-result', $client->getAgentPerms());
+        $this->assertSame('mock-result', $client->getAgentPermissions());
     }
 
-    public function testGet()
+    public function testGetUser()
     {
         $client = $this->mockApiClient(LinkedCorpClient::class);
 
@@ -35,10 +35,10 @@ class LinkedCorpClientTest extends TestCase
 
         $client->expects()->httpPostJson('cgi-bin/linkedcorp/user/get', $params)->andReturn('mock-result');
 
-        $this->assertSame('mock-result', $client->get('CORPID/USERID'));
+        $this->assertSame('mock-result', $client->getUser('CORPID/USERID'));
     }
 
-    public function testUserSimples()
+    public function testGetUsers()
     {
         $client = $this->mockApiClient(LinkedCorpClient::class);
 
@@ -49,10 +49,10 @@ class LinkedCorpClientTest extends TestCase
 
         $client->expects()->httpPostJson('cgi-bin/linkedcorp/user/simplelist', $params)->andReturn('mock-result');
 
-        $this->assertSame('mock-result', $client->userSimples('LINKEDID/DEPARTMENTID', true));
+        $this->assertSame('mock-result', $client->getUsers('LINKEDID/DEPARTMENTID', true));
     }
 
-    public function testUsers()
+    public function testGetDetailedUsers()
     {
         $client = $this->mockApiClient(LinkedCorpClient::class);
 
@@ -63,10 +63,10 @@ class LinkedCorpClientTest extends TestCase
 
         $client->expects()->httpPostJson('cgi-bin/linkedcorp/user/list', $params)->andReturn('mock-result');
 
-        $this->assertSame('mock-result', $client->users('LINKEDID/DEPARTMENTID', true));
+        $this->assertSame('mock-result', $client->getDetailedUsers('LINKEDID/DEPARTMENTID', true));
     }
 
-    public function testDepartments()
+    public function testGetDepartments()
     {
         $client = $this->mockApiClient(LinkedCorpClient::class);
 
@@ -76,6 +76,6 @@ class LinkedCorpClientTest extends TestCase
 
         $client->expects()->httpPostJson('cgi-bin/linkedcorp/department/list', $params)->andReturn('mock-result');
 
-        $this->assertSame('mock-result', $client->departments('LINKEDID/DEPARTMENTID'));
+        $this->assertSame('mock-result', $client->getDepartments('LINKEDID/DEPARTMENTID'));
     }
 }

--- a/tests/Work/User/LinkedCorpClientTest.php
+++ b/tests/Work/User/LinkedCorpClientTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\Tests\Work\User;
+
+use EasyWeChat\Tests\TestCase;
+use EasyWeChat\Work\User\LinkedCorpClient;
+
+class LinkedCorpClientTest extends TestCase
+{
+    public function testGetAgentPerms()
+    {
+        $client = $this->mockApiClient(LinkedCorpClient::class);
+
+        $client->expects()->httpPostJson('cgi-bin/linkedcorp/agent/get_perm_list')->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->getAgentPerms());
+    }
+
+    public function testGet()
+    {
+        $client = $this->mockApiClient(LinkedCorpClient::class);
+
+        $params = [
+            'userid' => 'CORPID/USERID'
+        ];
+
+        $client->expects()->httpPostJson('cgi-bin/linkedcorp/user/get', $params)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->get('CORPID/USERID'));
+    }
+
+    public function testUserSimples()
+    {
+        $client = $this->mockApiClient(LinkedCorpClient::class);
+
+        $params = [
+            'department_id' => 'LINKEDID/DEPARTMENTID',
+            'fetch_child' => 1
+        ];
+
+        $client->expects()->httpPostJson('cgi-bin/linkedcorp/user/simplelist', $params)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->userSimples('LINKEDID/DEPARTMENTID', true));
+    }
+
+    public function testUsers()
+    {
+        $client = $this->mockApiClient(LinkedCorpClient::class);
+
+        $params = [
+            'department_id' => 'LINKEDID/DEPARTMENTID',
+            'fetch_child' => 1
+        ];
+
+        $client->expects()->httpPostJson('cgi-bin/linkedcorp/user/list', $params)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->users('LINKEDID/DEPARTMENTID', true));
+    }
+
+    public function testDepartments()
+    {
+        $client = $this->mockApiClient(LinkedCorpClient::class);
+
+        $params = [
+            'department_id' => 'LINKEDID/DEPARTMENTID'
+        ];
+
+        $client->expects()->httpPostJson('cgi-bin/linkedcorp/department/list', $params)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->departments('LINKEDID/DEPARTMENTID'));
+    }
+}


### PR DESCRIPTION
【企业微信】新增通讯录(互联企业)
- 获取应用的可见范围
- 获取互联企业成员详细信息
- 获取互联企业部门成员
- 获取互联企业部门成员详情
- 获取互联企业部门列表

1.测试已写
2.已真号测试
3.合并后补上文档