### PR TITLE
[refactor]安装必要的依赖，解决升级 phpunit9.5 后单元测试报错

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     "mikey179/vfsstream": "^1.6",
     "mockery/mockery": "^1.4",
     "phpstan/phpstan": "^0.12",
-    "phpunit/phpunit": "^9.5"
+    "phpunit/phpunit": "^9.5",
+    "dms/phpunit-arraysubset-asserts": "^0.2.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
安装依赖，解决引用 DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts 报错的问题。