### PR TITLE
[bugfix]【企业微信】[上传普通文件]中文文件名不显示问题修复

### DIFF
--- a/src/Kernel/BaseClient.php
+++ b/src/Kernel/BaseClient.php
@@ -121,11 +121,19 @@ class BaseClient
     public function httpUpload(string $url, array $files = [], array $form = [], array $query = [])
     {
         $multipart = [];
+        $headers = [];
+
+        if(isset($form['filename'])){
+            $headers = [
+                'Content-Disposition' => 'form-data; name="media"; filename="'.$form['filename'].'"'
+            ];
+        }
 
         foreach ($files as $name => $path) {
             $multipart[] = [
                 'name' => $name,
                 'contents' => fopen($path, 'r'),
+                'headers' => $headers
             ];
         }
 

--- a/src/Work/Media/Client.php
+++ b/src/Work/Media/Client.php
@@ -53,7 +53,7 @@ class Client extends BaseClient
      *
      * @return mixed
      */
-    public function uploadImage(string $path)
+    public function uploadImage(string $path, array $form = [])
     {
         return $this->upload('image', $path);
     }
@@ -65,7 +65,7 @@ class Client extends BaseClient
      *
      * @return mixed
      */
-    public function uploadVoice(string $path)
+    public function uploadVoice(string $path, array $form = [])
     {
         return $this->upload('voice', $path);
     }
@@ -77,7 +77,7 @@ class Client extends BaseClient
      *
      * @return mixed
      */
-    public function uploadVideo(string $path)
+    public function uploadVideo(string $path, array $form = [])
     {
         return $this->upload('video', $path);
     }
@@ -89,9 +89,9 @@ class Client extends BaseClient
      *
      * @return mixed
      */
-    public function uploadFile(string $path)
+    public function uploadFile(string $path, array $form = [])
     {
-        return $this->upload('file', $path);
+        return $this->upload('file', $path, $form);
     }
 
     /**
@@ -105,12 +105,12 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function upload(string $type, string $path)
+    public function upload(string $type, string $path, array $form = [])
     {
         $files = [
             'media' => $path,
         ];
 
-        return $this->httpUpload('cgi-bin/media/upload', $files, [], compact('type'));
+        return $this->httpUpload('cgi-bin/media/upload', $files, $form, compact('type'));
     }
 }


### PR DESCRIPTION
【企业微信】[上传普通文件]中文文件名不显示问题修复

问题: 在linux由于编码问题,不传filename情况下,可以上传成功,但中文名不显示
使用场景: 在企业微信中经常用于发送 pdf ppt 等文件时,需要中文名显示



决解方案: 在原有方法上新增可选参数 $form 经测试guzzle 光添加formdata对企业微信还是不起作用, 最终在Content-Disposition添加参数有效

企业微信原文档 https://open.work.weixin.qq.com/api/doc/90000/90135/90253

1.已经过真号测试
2.公众号不受影响(公众号没有上传普通文件)
3.合并后完善文档
