### PR TITLE
fix:修复发送企业微信欢迎语图片消息的时候必须使用media_id的限制，详情请参照https://work.weixin.qq.com…

### DIFF
--- a/src/Work/ExternalContact/MessageClient.php
+++ b/src/Work/ExternalContact/MessageClient.php
@@ -26,14 +26,14 @@ class MessageClient extends BaseClient
      *
      * @var array
      */
-    protected $required = ['content', 'media_id', 'title', 'url', 'pic_media_id', 'appid', 'page'];
+    protected $required = ['content', 'title', 'url', 'pic_media_id', 'appid', 'page'];
 
     protected $textMessage = [
         'content' => '',
     ];
 
     protected $imageMessage = [
-        'media_id' => '',
+        
     ];
 
     protected $linkMessage = [


### PR DESCRIPTION
修复发送企业微信欢迎语图片消息的时候必须使用media_id的限制，详情请参照https://work.weixin.qq.com/api/doc/90000/90135/92137