### PR TITLE
add mini-program environment config

### DIFF
--- a/src/MiniProgram/SubscribeMessage/Client.php
+++ b/src/MiniProgram/SubscribeMessage/Client.php
@@ -30,6 +30,7 @@ class Client extends BaseClient
         'template_id' => '',
         'page' => '',
         'data' => [],
+        'miniprogram_state' => '',
     ];
 
     /**

--- a/src/MiniProgram/SubscribeMessage/Client.php
+++ b/src/MiniProgram/SubscribeMessage/Client.php
@@ -30,7 +30,7 @@ class Client extends BaseClient
         'template_id' => '',
         'page' => '',
         'data' => [],
-        'miniprogram_state' => '',
+        'miniprogram_state' => 'formal',
     ];
 
     /**


### PR DESCRIPTION
点击订阅消息跳转小程序时 默认是跳转正式版的小程序，无法在体验版和开发板进行测试
https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/subscribe-message/subscribeMessage.send.html

```php
$data = [
    'template_id' => 'bDmywsp2oEHjwAadTGKkUJ-eJEiMiOf7H-dZ7wjdw80', // 所需下发的订阅模板id
    'touser' => 'oSyZp5OBNPBRhG-7BVgWxbiNZm',     // 接收者（用户）的 openid
    'page' => '',      
    'miniprogram_state' => '', //developer为开发版；trial为体验版；formal为正式版；默认为正式版
    'data'=>[]
]
```

