### PR TITLE
env文件中配置的agent_id  无法在message注册时自动设置。因为类型判断错误。

### DIFF
--- a/src/Work/Message/ServiceProvider.php
+++ b/src/Work/Message/ServiceProvider.php
@@ -33,7 +33,7 @@ class ServiceProvider implements ServiceProviderInterface
         $app['messenger'] = function ($app) {
             $messenger = new Messenger($app['message']);
 
-            if (is_int($app['config']['agent_id'])) {
+            if (is_numeric($app['config']['agent_id'])) {
                 $messenger->ofAgent($app['config']['agent_id']);
             }
 


### PR DESCRIPTION
这里应该使用 `is_numeric` `is_int` 的话 数字字符串无法通过。那么通过.env 文件配置的agent_id 就无法自动设置。只能在 发消息前 手动调用一次 `->ofAgent()`方法。