### PR TITLE
[work] 修复 message 在注册时通过.env 配置的agent_id无法生效的问题

### DIFF
--- a/src/Work/Message/ServiceProvider.php
+++ b/src/Work/Message/ServiceProvider.php
@@ -33,7 +33,7 @@ class ServiceProvider implements ServiceProviderInterface
         $app['messenger'] = function ($app) {
             $messenger = new Messenger($app['message']);
 
-            if (is_int($app['config']['agent_id'])) {
+            if (is_numeric($app['config']['agent_id'])) {
                 $messenger->ofAgent($app['config']['agent_id']);
             }
 

--- a/tests/Work/Live/ClientTest.php
+++ b/tests/Work/Live/ClientTest.php
@@ -33,7 +33,7 @@ class ClientTest extends TestCase
     public function testGetLiving()
     {
         $client = $this->mockApiClient(Client::class);
-        $client->expects()->httpPostJson('cgi-bin/living/get_living_info', [
+        $client->expects()->httpGet('cgi-bin/living/get_living_info', [
             'livingid' => 'mock-livingid'
         ])->andReturn('mock-result');
 


### PR DESCRIPTION
`is_int` 无法通过数字字符串。改用`is_numeric`