### PR TITLE
[feature][work]企业微信分配在职成员的客户,分配离职成员的客户,查询客户接替状态接口新增

### DIFF
--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -97,9 +97,9 @@ class Client extends BaseClient
      *
      * @see https://work.weixin.qq.com/api/doc/90001/90143/93010
      *
-     * @param  string  $userId
-     * @param  string  $cursor
-     * @param  int  $limit
+     * @param string $userId
+     * @param string $cursor
+     * @param int $limit
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
@@ -139,22 +139,28 @@ class Client extends BaseClient
     /**
      * 获取离职成员的客户列表.
      *
-     * @see https://work.weixin.qq.com/api/doc#90000/90135/91563
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92124
      *
      * @param int $pageId
      * @param int $pageSize
+     * @param string $cursor
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function getUnassigned(int $pageId = 0, int $pageSize = 1000)
+    public function getUnassigned(int $pageId = 0, int $pageSize = 1000, ?string $cursor = null)
     {
-        return $this->httpPostJson('cgi-bin/externalcontact/get_unassigned_list', [
+        $params = [
             'page_id' => $pageId,
             'page_size' => $pageSize,
-        ]);
+            'cursor' => $cursor,
+        ];
+        $writableParams = array_filter($params, function (string $key) use ($params) {
+            return $params[$key] ?? null;
+        }, ARRAY_FILTER_USE_KEY);
+        return $this->httpPostJson('cgi-bin/externalcontact/get_unassigned_list', $writableParams);
     }
 
     /**
@@ -185,6 +191,57 @@ class Client extends BaseClient
     }
 
     /**
+     * 分配在职成员的客户.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92125
+     *
+     * @param array $externalUserId
+     * @param string $handoverUserId
+     * @param string $takeoverUserId
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function transferCustomer(array $externalUserId, string $handoverUserId, string $takeoverUserId, string $transferSuccessMessage)
+    {
+        $params = [
+            'external_userid' => $externalUserId,
+            'handover_userid' => $handoverUserId,
+            'takeover_userid' => $takeoverUserId,
+            'transfer_success_msg' => $transferSuccessMessage
+        ];
+
+        return $this->httpPostJson('cgi-bin/externalcontact/transfer_customer', $params);
+    }
+
+    /**
+     * 分配离职成员的客户.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/94081
+     *
+     * @param array $externalUserId
+     * @param string $handoverUserId
+     * @param string $takeoverUserId
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function resignedTransferCustomer(array $externalUserId, string $handoverUserId, string $takeoverUserId)
+    {
+        $params = [
+            'external_userid' => $externalUserId,
+            'handover_userid' => $handoverUserId,
+            'takeover_userid' => $takeoverUserId,
+        ];
+
+        return $this->httpPostJson('cgi-bin/externalcontact/resigned/transfer_customer', $params);
+    }
+
+    /**
      * 离职成员的群再分配.
      *
      * @see https://work.weixin.qq.com/api/doc/90000/90135/92127
@@ -205,6 +262,31 @@ class Client extends BaseClient
         ];
 
         return $this->httpPostJson('cgi-bin/externalcontact/groupchat/transfer', $params);
+    }
+
+    /**
+     * 查询客户接替状态.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/94082
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @param string $handoverUserId
+     * @param string $takeoverUserId
+     * @param string $cursor
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function transferResult(string $handoverUserId, string $takeoverUserId, $cursor = null)
+    {
+        $params = [
+            'handover_userid' => $handoverUserId,
+            'takeover_userid' => $takeoverUserId,
+            'cursor' => $cursor,
+        ];
+
+        return $this->httpPostJson('cgi-bin/externalcontact/get_transfer_result', $params);
     }
 
     /**
@@ -295,7 +377,6 @@ class Client extends BaseClient
 
         return $this->httpPostJson('cgi-bin/externalcontact/get_corp_tag_list', $params);
     }
-
 
 
     /**

--- a/tests/OpenPlatform/ApplicationTest.php
+++ b/tests/OpenPlatform/ApplicationTest.php
@@ -110,7 +110,7 @@ class ApplicationTest extends TestCase
     public function testMiniProgram()
     {
         $app = new Application(['app_id' => 'component-app-id', 'secret' => 'component-secret', 'token' => 'component-token', 'aes_key' => 'Qqx2S6jV3mp5prWPg5x3eBmeU1kLayZio4Q9ZxWTbmf']);
-        $miniProgram = $app->miniProgram('app-id', 'refresh-token');
+        $miniProgram = $app->miniProgram('app-id', 'refresh-token', null);
 
         $this->assertInstanceOf('EasyWeChat\MiniProgram\Application', $miniProgram);
         $this->assertInstanceOf('\EasyWeChat\MiniProgram\Encryptor', $miniProgram->encryptor);

--- a/tests/Work/ExternalContact/ClientTest.php
+++ b/tests/Work/ExternalContact/ClientTest.php
@@ -122,6 +122,35 @@ class ClientTest extends TestCase
         $this->assertSame('mock-result', $client->transfer('mock-external-userid', 'mock-handover-userid', 'mock-takeover-userid', 'message'));
     }
 
+    public function testTransferCustomer()
+    {
+        $client = $this->mockApiClient(Client::class);
+
+        $params = [
+            'external_userid' => ['mock-external-userid'],
+            'handover_userid' => 'mock-handover-userid',
+            'takeover_userid' => 'mock-takeover-userid',
+            'transfer_success_msg' => 'message',
+        ];
+        $client->expects()->httpPostJson('cgi-bin/externalcontact/transfer_customer', $params)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->transferCustomer(['mock-external-userid'], 'mock-handover-userid', 'mock-takeover-userid', 'message'));
+    }
+
+    public function testResignedTransferCustomer()
+    {
+        $client = $this->mockApiClient(Client::class);
+
+        $params = [
+            'external_userid' => ['mock-external-userid'],
+            'handover_userid' => 'mock-handover-userid',
+            'takeover_userid' => 'mock-takeover-userid',
+        ];
+        $client->expects()->httpPostJson('cgi-bin/externalcontact/resigned/transfer_customer', $params)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->resignedTransferCustomer(['mock-external-userid'], 'mock-handover-userid', 'mock-takeover-userid'));
+    }
+
     public function testTransferGroupChat(): void
     {
         $client = $this->mockApiClient(Client::class);
@@ -133,6 +162,20 @@ class ClientTest extends TestCase
         $client->expects()->httpPostJson('cgi-bin/externalcontact/groupchat/transfer', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->transferGroupChat(['群聊id1', '群聊id2'], '接替群主userid'));
+    }
+
+    public function testTransferResult(): void
+    {
+        $client = $this->mockApiClient(Client::class);
+
+        $params = [
+            'handover_userid' => 'zhangsan',
+            'takeover_userid' => 'lisi',
+            'cursor' => 'cursor',
+        ];
+        $client->expects()->httpPostJson('cgi-bin/externalcontact/get_transfer_result', $params)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->transferResult('zhangsan', 'lisi', 'cursor'));
     }
 
     public function testGetTransferResult(): void


### PR DESCRIPTION
新增:
企业微信分配在职成员的客户接口 [接口文档:https://work.weixin.qq.com/api/doc/90000/90135/92125]
企业微信分配离职成员的客户接口 [接口文档:https://work.weixin.qq.com/api/doc/90000/90135/94081]
企业微信查询客户接替状态接口接口 [接口文档:https://work.weixin.qq.com/api/doc/90000/90135/94082]

优化:
企业微信获取待分配的离职成员列表接口支持游标查询 [接口文档:https://work.weixin.qq.com/api/doc/90000/90135/92124]