### PR TITLE
[fixed]查询客户接替状态请求地址错误修复

### DIFF
--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -273,12 +273,12 @@ class Client extends BaseClient
      *
      * @param string $handoverUserId
      * @param string $takeoverUserId
-     * @param string $cursor
+     * @param null|string $cursor
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function transferResult(string $handoverUserId, string $takeoverUserId, $cursor = null)
+    public function transferResult(string $handoverUserId, string $takeoverUserId, ?string $cursor = null)
     {
         $params = [
             'handover_userid' => $handoverUserId,
@@ -286,7 +286,7 @@ class Client extends BaseClient
             'cursor' => $cursor,
         ];
 
-        return $this->httpPostJson('cgi-bin/externalcontact/get_transfer_result', $params);
+        return $this->httpPostJson('cgi-bin/externalcontact/resigned/transfer_result', $params);
     }
 
     /**


### PR DESCRIPTION
查询客户接替状态请求地址错误,之前请求的是老地址已修改为新地址

新接口文档:https://work.weixin.qq.com/api/doc/90000/90135/94082
老接口文档:https://work.weixin.qq.com/api/doc/23225