### PR TITLE
[feature]企业微信获取客户群详情增加need_name参数

### DIFF
--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -338,6 +338,7 @@ class Client extends BaseClient
      * @see https://work.weixin.qq.com/api/doc/90000/90135/92122
      *
      * @param string $chatId
+     * @param int $need_name
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
@@ -345,10 +346,11 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
 
-    public function getGroupChat(string $chatId)
+    public function getGroupChat(string $chatId, int $need_name = 0)
     {
         $params = [
-            'chat_id' => $chatId
+            'chat_id' => $chatId,
+            'need_name' => $need_name,
         ];
 
         return $this->httpPostJson('cgi-bin/externalcontact/groupchat/get', $params);

--- a/tests/Work/ExternalContact/ClientTest.php
+++ b/tests/Work/ExternalContact/ClientTest.php
@@ -215,11 +215,20 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
 
         $params = [
-            'chat_id' => 'CHAT_ID_1'
+            'chat_id' => 'CHAT_ID_1',
+            'need_name' => 0
         ];
         $client->expects()->httpPostJson('cgi-bin/externalcontact/groupchat/get', $params)->andReturn('mock-result');
 
         $this->assertSame('mock-result', $client->getGroupChat('CHAT_ID_1'));
+
+        $params = [
+            'chat_id' => 'CHAT_ID_1',
+            'need_name' => 1
+        ];
+        $client->expects()->httpPostJson('cgi-bin/externalcontact/groupchat/get', $params)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->getGroupChat('CHAT_ID_1', 1));
     }
 
     public function testGetCorpTags(): void


### PR DESCRIPTION
https://work.weixin.qq.com/api/doc/90000/90135/92122
![image](https://user-images.githubusercontent.com/24811226/129163404-27c5f410-3401-4e9f-b10a-46ad92e785b2.png)
接口增加了need_name参数以区分是否需要返回群成员的名字，0-不返回；1-返回。默认不返回
新增前
![image](https://user-images.githubusercontent.com/24811226/129164144-7b5ac89c-9542-4523-98c8-7ca7a40b7a82.png)
新增后
![image](https://user-images.githubusercontent.com/24811226/129164025-96b13c75-b2e2-4e0a-9b55-15539cb14555.png)
