### PR TITLE
添加客户端调起支付 api 签名生成方法

### DIFF
--- a/src/Pay/Signature.php
+++ b/src/Pay/Signature.php
@@ -46,4 +46,33 @@ class Signature
             )
         );
     }
+
+    /**
+     * get client call payment sign
+     *
+     * @param  string  $appId
+     * @param  string  $prepayId
+     * @return array
+     */
+    public function createPaymentSign(string $appId, string $prepayId): array
+    {
+        $package = 'prepay_id=' . $prepayId;
+        $nonce = \uniqid('nonce');
+        $timestamp = \time();
+
+        $message = $appId . "\n" .
+            $timestamp . "\n" .
+            $nonce . "\n" .
+            $package . "\n";
+
+        \openssl_sign($message, $signature, $this->merchant->getPrivateKey(), 'sha256WithRSAEncryption');
+
+        return [
+            'timeStamp' => (string) $timestamp,
+            'nonceStr'  => $nonce,
+            'package'   => $package,
+            'signType'  => 'RSA',
+            'paySign'   => \base64_encode($signature),
+        ];
+    }
 }


### PR DESCRIPTION
增加通过服务端下单接口获取到发起支付的必要参数 prepay_id 后，应用内调起支付需要的 pay sign 生成方法