### PR TITLE
[feature][work]企业微信 增加 外部联系人unionid转换,代开发应用external_userid转换 接口

### DIFF
--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -475,4 +475,50 @@ class Client extends BaseClient
     {
         return $this->httpPostJson('cgi-bin/externalcontact/mark_tag', $params);
     }
+
+    /**
+     * 外部联系人unionid转换.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92115
+     *
+     * @param string|null $unionid 微信客户的unionid
+     * @param string|null $openid 微信客户的openid
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function unionidToExternalUserid(?string $unionid = null, ?string $openid = null)
+    {
+        return $this->httpPostJson(
+            'cgi-bin/externalcontact/unionid_to_external_userid',
+            [
+                'unionid' => $unionid,
+                'openid' => $openid,
+            ]
+        );
+    }
+
+    /**
+     * 代开发应用external_userid转换.
+     *
+     * @see https://work.weixin.qq.com/api/doc/90000/90135/92115
+     *
+     * @param string $externalUserid 代开发自建应用获取到的外部联系人ID
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function toServiceExternalUserid(string $externalUserid)
+    {
+        return $this->httpPostJson(
+            'cgi-bin/externalcontact/to_service_external_userid',
+            [
+                'external_userid' => $externalUserid,
+            ]
+        );
+    }
 }

--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -479,7 +479,7 @@ class Client extends BaseClient
     /**
      * 外部联系人unionid转换.
      *
-     * @see https://work.weixin.qq.com/api/doc/90000/90135/92115
+     * @see https://work.weixin.qq.com/api/doc/90001/90143/93274
      *
      * @param string|null $unionid 微信客户的unionid
      * @param string|null $openid 微信客户的openid
@@ -503,7 +503,7 @@ class Client extends BaseClient
     /**
      * 代开发应用external_userid转换.
      *
-     * @see https://work.weixin.qq.com/api/doc/90000/90135/92115
+     * @see https://work.weixin.qq.com/api/doc/90001/90143/95195
      *
      * @param string $externalUserid 代开发自建应用获取到的外部联系人ID
      *

--- a/tests/Work/ExternalContact/ClientTest.php
+++ b/tests/Work/ExternalContact/ClientTest.php
@@ -309,4 +309,21 @@ class ClientTest extends TestCase
 
         $this->assertSame('mock-result', $client->markTags($params));
     }
+
+    public function testUnionidToExternalUserid(): void
+    {
+        $client = $this->mockApiClient(Client::class);
+        $unionid = 'unionid';
+        $openid = 'openid';
+        $client->expects()->httpPostJson('cgi-bin/externalcontact/unionid_to_external_userid', ['unionid' => $unionid, 'openid' => $openid])->andReturn('mock-result');
+        $this->assertSame('mock-result', $client->unionidToExternalUserid($unionid, $openid));
+    }
+
+    public function testToServiceExternalUserid(): void
+    {
+        $client = $this->mockApiClient(Client::class);
+        $externalUserid = 'externalUserid';
+        $client->expects()->httpPostJson('cgi-bin/externalcontact/to_service_external_userid', ['external_userid' => $externalUserid])->andReturn('mock-result');
+        $this->assertSame('mock-result', $client->toServiceExternalUserid($externalUserid));
+    }
 }


### PR DESCRIPTION
企业微信 增加接口

- 外部联系人unionid转换(第三方模式请求才会起作用)
[https://work.weixin.qq.com/api/doc/90001/90143/93274](https://work.weixin.qq.com/api/doc/90001/90143/93274)
- 代开发应用external_userid转换(必须是代开发应用)
[https://work.weixin.qq.com/api/doc/90001/90143/95195](https://work.weixin.qq.com/api/doc/90001/90143/95195)

代开发应用文档地址
[https://work.weixin.qq.com/api/doc/33971](https://work.weixin.qq.com/api/doc/33971)

代开发应用答疑
[https://developers.weixin.qq.com/community/enterprisewechat/doc/000e6c12e84ec0bdc39c906b25b800](https://developers.weixin.qq.com/community/enterprisewechat/doc/000e6c12e84ec0bdc39c906b25b800)