### PR TITLE
[fixbug][work]企业微信 批量获取客户详情参数错误

### DIFF
--- a/src/Work/ExternalContact/Client.php
+++ b/src/Work/ExternalContact/Client.php
@@ -57,7 +57,7 @@ class Client extends BaseClient
      *
      * @see https://work.weixin.qq.com/api/doc/90000/90135/92994
      *
-     * @param string $userId
+     * @param array $userIdList
      * @param string $cursor
      * @param integer $limit
      *
@@ -65,10 +65,10 @@ class Client extends BaseClient
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException|\GuzzleHttp\Exception\GuzzleException
      */
-    public function batchGet(string $userId, string $cursor = '', int $limit = 100)
+    public function batchGet(array $userIdList, string $cursor = '', int $limit = 100)
     {
         return $this->httpPostJson('cgi-bin/externalcontact/batch/get_by_user', [
-            'userid' => $userId,
+            'userid_list' => $userIdList,
             'cursor' => $cursor,
             'limit' => $limit,
         ]);
@@ -97,7 +97,7 @@ class Client extends BaseClient
      *
      * @see https://work.weixin.qq.com/api/doc/90001/90143/93010
      *
-     * @param string $userId
+     * @param array $userIdList
      * @param string $cursor
      * @param int $limit
      *
@@ -106,10 +106,10 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function batchGetByUser(string $userId, string $cursor, int $limit)
+    public function batchGetByUser(array $userIdList, string $cursor, int $limit)
     {
         return $this->httpPostJson('cgi-bin/externalcontact/batch/get_by_user', [
-            'userid' => $userId,
+            'userid_list' => $userIdList,
             'cursor' => $cursor,
             'limit' => $limit
         ]);

--- a/tests/Work/ExternalContact/ClientTest.php
+++ b/tests/Work/ExternalContact/ClientTest.php
@@ -67,13 +67,13 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class);
 
         $params = [
-            'userid' => 'rocky',
+            'userid_list' => ['rocky'],
             'cursor' => '',
-            'limit' => 1000,
+            'limit' => 100,
         ];
         $client->expects()->httpPostJson('cgi-bin/externalcontact/batch/get_by_user', $params)->andReturn('mock-result');
 
-        $this->assertSame('mock-result', $client->batchGet('rocky', '', 1000));
+        $this->assertSame('mock-result', $client->batchGet(['rocky'], '', 100));
     }
 
     public function testRemark(): void


### PR DESCRIPTION
官方接口地址 
- 服务商 https://work.weixin.qq.com/api/doc/90001/90143/93010
- 企业内部 https://work.weixin.qq.com/api/doc/90000/90135/92994