### PR TITLE
新增 企业微信获取企业已配置的「联系我」列表

### DIFF
--- a/src/Work/ExternalContact/ContactWayClient.php
+++ b/src/Work/ExternalContact/ContactWayClient.php
@@ -95,4 +95,28 @@ class ContactWayClient extends BaseClient
             'config_id' => $configId,
         ]);
     }
+
+    /**
+     * 获取企业已配置的「联系我」列表，注意，该接口仅可获取2021年7月10日以后创建的「联系我」
+     *
+     * @param string $cursor 分页查询使用的游标，为上次请求返回的 next_cursor
+     * @param int $limit 每次查询的分页大小，默认为100条，最多支持1000条
+     * @param int|null $startTime 「联系我」创建起始时间戳, 不传默认为90天前
+     * @param int|null $endTime 「联系我」创建结束时间戳, 不传默认为当前时间
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function list(string $cursor = '', int $limit = 100, int $startTime = null, int $endTime = null)
+    {
+        $data = [
+            'cursor' => $cursor,
+            'limit' => $limit,
+        ];
+        if ($startTime) $data['start_time'] = $startTime;
+        if ($endTime) $data['end_time'] = $endTime;
+        return $this->httpPostJson('cgi-bin/externalcontact/list_contact_way', $data);
+    }
 }

--- a/tests/Work/ExternalContact/ContactWayTest.php
+++ b/tests/Work/ExternalContact/ContactWayTest.php
@@ -85,4 +85,19 @@ class ContactWayTest extends TestCase
 
         $this->assertSame('mock-result', $client->delete($configId));
     }
+
+    public function testList()
+    {
+        $client = $this->mockApiClient(ContactWayClient::class);
+        $params = [
+            'start_time' => 1638892800,
+            'end_time' => 1638979200,
+            'cursor' => 'CURSOR',
+            'limit' => 1000
+        ];
+
+        $client->expects()->httpPostJson('cgi-bin/externalcontact/list_contact_way', $params)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->list('CURSOR', 1000, 1638892800, 1638979200));
+    }
 }


### PR DESCRIPTION
获取企业已配置的「联系我」列表，**注意，该接口仅可获取2021年7月10日以后创建的「联系我」**