### PR TITLE
解决Laravel 安装的依赖冲突

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "overtrue/socialite": "^3.2",
     "pimple/pimple": "^3.0",
     "psr/simple-cache": "^1.0",
-    "symfony/cache": "^3.3 || ^4.3 || ^5.0",
-    "symfony/event-dispatcher": "^4.3 || ^5.0",
+    "symfony/cache": "^3.3 || ^4.3 || ^5.0||^6.0",
+    "symfony/event-dispatcher": "^4.3 || ^5.0 || ^6.0",
     "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0 || ^5.0",
     "symfony/psr-http-message-bridge": "^0.3 || ^1.0 || ^2.0",
     "ext-libxml": "*"


### PR DESCRIPTION
最新版 Laravel(v8.77.1)安装时有依赖冲突