### PR TITLE
V2版本签名修复

### DIFF
--- a/src/Pay/LegacySignature.php
+++ b/src/Pay/LegacySignature.php
@@ -19,7 +19,6 @@ class LegacySignature
         $params = $attributes = array_filter(
             \array_merge(
                 [
-                    'mch_id' => $this->merchant->getMerchantId(),
                     'nonce_str' => $nonce,
                     'sub_mch_id' => $params['sub_mch_id'] ?? null,
                     'sub_appid' => $params['sub_appid'] ?? null,

--- a/src/Pay/LegacySignature.php
+++ b/src/Pay/LegacySignature.php
@@ -38,7 +38,7 @@ class LegacySignature
             $signType = 'md5';
         }
 
-        $params['sign'] = strtoupper(call_user_func_array($signType, [urldecode(http_build_query($params))]));
+        $params['sign'] = strtoupper(call_user_func_array($signType, [urldecode(http_build_query($attributes))]));
 
         return $params;
     }


### PR DESCRIPTION
删除该行是因为，如果调用的是‘现金红包’接口，则传入 mch_id 是正确的，但是如果使用的是‘付款到零钱 ’则需要传入 mchid 。这是时候微信就会返回 签名错误 。
其解决办法是商户号由外部参数传入。