### PR TITLE
优化base_uri

### DIFF
--- a/src/BasicService/ContentSecurity/Client.php
+++ b/src/BasicService/ContentSecurity/Client.php
@@ -37,7 +37,7 @@ class Client extends BaseClient
             'content' => $text,
         ];
 
-        return $this->httpPostJson('/wxa/msg_sec_check', $params);
+        return $this->httpPostJson('wxa/msg_sec_check', $params);
     }
 
     /**
@@ -52,7 +52,7 @@ class Client extends BaseClient
      */
     public function checkImage(string $path)
     {
-        return $this->httpUpload('/wxa/img_sec_check', ['media' => $path]);
+        return $this->httpUpload('wxa/img_sec_check', ['media' => $path]);
     }
 
     /**
@@ -83,7 +83,7 @@ class Client extends BaseClient
             'media_type' => $mediaType,
         ];
 
-        return $this->httpPostJson('/wxa/media_check_async', $params);
+        return $this->httpPostJson('wxa/media_check_async', $params);
     }
 
     /**

--- a/src/BasicService/Jssdk/Client.php
+++ b/src/BasicService/Jssdk/Client.php
@@ -28,7 +28,7 @@ class Client extends BaseClient
     /**
      * @var string
      */
-    protected $ticketEndpoint = '/cgi-bin/ticket/getticket';
+    protected $ticketEndpoint = 'cgi-bin/ticket/getticket';
 
     /**
      * Current URI.

--- a/src/BasicService/Media/Client.php
+++ b/src/BasicService/Media/Client.php
@@ -111,7 +111,7 @@ class Client extends BaseClient
             throw new InvalidArgumentException(sprintf("Unsupported media type: '%s'", $type));
         }
 
-        return $this->httpUpload('/cgi-bin/media/upload', ['media' => $path], ['type' => $type]);
+        return $this->httpUpload('cgi-bin/media/upload', ['media' => $path], ['type' => $type]);
     }
 
     /**
@@ -150,7 +150,7 @@ class Client extends BaseClient
      */
     public function createVideoForBroadcasting(string $mediaId, string $title, string $description)
     {
-        return $this->httpPostJson('/cgi-bin/media/uploadvideo', [
+        return $this->httpPostJson('cgi-bin/media/uploadvideo', [
             'media_id' => $mediaId,
             'title' => $title,
             'description' => $description,
@@ -169,7 +169,7 @@ class Client extends BaseClient
      */
     public function get(string $mediaId)
     {
-        $response = $this->requestRaw('/cgi-bin/media/get', 'GET', [
+        $response = $this->requestRaw('cgi-bin/media/get', 'GET', [
             'query' => [
                 'media_id' => $mediaId,
             ],
@@ -192,7 +192,7 @@ class Client extends BaseClient
      */
     public function getJssdkMedia(string $mediaId)
     {
-        $response = $this->requestRaw('/cgi-bin/media/get/jssdk', 'GET', [
+        $response = $this->requestRaw('cgi-bin/media/get/jssdk', 'GET', [
             'query' => [
                 'media_id' => $mediaId,
             ],

--- a/src/BasicService/QrCode/Client.php
+++ b/src/BasicService/QrCode/Client.php
@@ -110,6 +110,6 @@ class Client extends BaseClient
             $params['expire_seconds'] = min($expireSeconds, 30 * self::DAY);
         }
 
-        return $this->httpPostJson('/cgi-bin/qrcode/create', $params);
+        return $this->httpPostJson('cgi-bin/qrcode/create', $params);
     }
 }

--- a/src/MiniProgram/Auth/AccessToken.php
+++ b/src/MiniProgram/Auth/AccessToken.php
@@ -23,7 +23,7 @@ class AccessToken extends BaseAccessToken
     /**
      * @var string
      */
-    protected $endpointToGetToken = '/cgi-bin/token';
+    protected $endpointToGetToken = 'cgi-bin/token';
 
     /**
      * {@inheritdoc}

--- a/src/MiniProgram/OpenData/Client.php
+++ b/src/MiniProgram/OpenData/Client.php
@@ -41,7 +41,7 @@ class Client extends BaseClient
             'signature' => hash_hmac('sha256', json_encode($data), $sessionKey),
         ];
 
-        return $this->httpPostJson('/wxa/remove_user_storage', $data, $query);
+        return $this->httpPostJson('wxa/remove_user_storage', $data, $query);
     }
 
     /**
@@ -67,7 +67,7 @@ class Client extends BaseClient
             'signature' => hash_hmac('sha256', json_encode($data), $sessionKey),
         ];
 
-        return $this->httpPostJson('/wxa/set_user_storage', $data, $query);
+        return $this->httpPostJson('wxa/set_user_storage', $data, $query);
     }
 
     /**

--- a/src/MiniProgram/PhoneNumber/Client.php
+++ b/src/MiniProgram/PhoneNumber/Client.php
@@ -42,6 +42,6 @@ class Client extends BaseClient
             'code' => $code
         ];
 
-        return $this->httpPostJson('/wxa/business/getuserphonenumber', $params);
+        return $this->httpPostJson('wxa/business/getuserphonenumber', $params);
     }
 }

--- a/src/OfficialAccount/Auth/AccessToken.php
+++ b/src/OfficialAccount/Auth/AccessToken.php
@@ -23,7 +23,7 @@ class AccessToken extends BaseAccessToken
     /**
      * @var string
      */
-    protected $endpointToGetToken = '/cgi-bin/token';
+    protected $endpointToGetToken = 'cgi-bin/token';
 
     /**
      * @return array

--- a/tests/BasicService/ContentSecurity/ClientTest.php
+++ b/tests/BasicService/ContentSecurity/ClientTest.php
@@ -21,7 +21,7 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class, 'checkText')->shouldAllowMockingProtectedMethods();
         $client->makePartial();
 
-        $client->expects()->httpPostJson('/wxa/msg_sec_check', [
+        $client->expects()->httpPostJson('wxa/msg_sec_check', [
             'content' => 'foo',
         ])->andReturn('mock-result');
 
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
 
         $imagePath = 'foo';
 
-        $client->expects()->httpUpload('/wxa/img_sec_check', [
+        $client->expects()->httpUpload('wxa/img_sec_check', [
             'media' => $imagePath,
         ])->andReturn('mock-result');
 

--- a/tests/BasicService/Jssdk/ClientTest.php
+++ b/tests/BasicService/Jssdk/ClientTest.php
@@ -83,7 +83,7 @@ class ClientTest extends TestCase
         $cache->expects()->has($cacheKey)->twice()->andReturns(false, true);
         $cache->expects()->get($cacheKey)->never();
         $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500);
-        $client->expects()->requestRaw('/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
+        $client->expects()->requestRaw('cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
 
         $this->assertSame($ticket, $client->getTicket());
 
@@ -91,7 +91,7 @@ class ClientTest extends TestCase
         $cache->expects()->has($cacheKey)->andReturn(true);
         $cache->expects()->get($cacheKey)->never();
         $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500);
-        $client->expects()->requestRaw('/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
+        $client->expects()->requestRaw('cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
 
         $this->assertSame($ticket, $client->getTicket(true));
 
@@ -101,7 +101,7 @@ class ClientTest extends TestCase
 
         $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500);
         $cache->expects()->has($cacheKey)->andReturn(false);
-        $client->expects()->requestRaw('/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
+        $client->expects()->requestRaw('cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'jsapi']])->andReturn($response);
 
         $client->getTicket(true);
     }

--- a/tests/BasicService/Media/ClientTest.php
+++ b/tests/BasicService/Media/ClientTest.php
@@ -57,7 +57,7 @@ class ClientTest extends TestCase
         $client = $this->mockApiClient(Client::class, ['httpUpload']);
 
         $path = STUBS_ROOT.'/files/image.jpg';
-        $client->expects()->httpUpload('/cgi-bin/media/upload', ['media' => $path], ['type' => 'image'])->andReturn('mock-response');
+        $client->expects()->httpUpload('cgi-bin/media/upload', ['media' => $path], ['type' => 'image'])->andReturn('mock-response');
 
         $client->upload('image', $path);
 
@@ -103,7 +103,7 @@ class ClientTest extends TestCase
         $mediaId = 'mock-media-id';
         $title = 'mock-title';
         $description = 'mock-description';
-        $client->expects()->httpPostJson('/cgi-bin/media/uploadvideo', [
+        $client->expects()->httpPostJson('cgi-bin/media/uploadvideo', [
             'media_id' => $mediaId,
             'title' => $title,
             'description' => $description,
@@ -119,7 +119,7 @@ class ClientTest extends TestCase
 
         $mediaId = 'invalid-media-id';
         $imageResponse = new Response(200, ['content-type' => 'text/plain'], '{"error": "invalid media id hits."}');
-        $client->expects()->requestRaw('/cgi-bin/media/get', 'GET', [
+        $client->expects()->requestRaw('cgi-bin/media/get', 'GET', [
             'query' => [
                 'media_id' => $mediaId,
             ],
@@ -129,7 +129,7 @@ class ClientTest extends TestCase
 
         $mediaId = 'valid-media-id';
         $imageResponse = new Response(200, ['content-disposition' => 'attachment'], 'valid data');
-        $client->expects()->requestRaw('/cgi-bin/media/get', 'GET', [
+        $client->expects()->requestRaw('cgi-bin/media/get', 'GET', [
             'query' => [
                 'media_id' => $mediaId,
             ],
@@ -145,7 +145,7 @@ class ClientTest extends TestCase
 
         $mediaId = 'invalid-media-id';
         $imageResponse = new Response(200, ['content-type' => 'text/plain'], '{"error": "invalid media id hits."}');
-        $client->expects()->requestRaw('/cgi-bin/media/get/jssdk', 'GET', [
+        $client->expects()->requestRaw('cgi-bin/media/get/jssdk', 'GET', [
             'query' => [
                 'media_id' => $mediaId,
             ],
@@ -155,7 +155,7 @@ class ClientTest extends TestCase
 
         $mediaId = 'valid-media-id';
         $imageResponse = new Response(200, ['content-disposition' => 'attachment'], 'valid data');
-        $client->expects()->requestRaw('/cgi-bin/media/get/jssdk', 'GET', [
+        $client->expects()->requestRaw('cgi-bin/media/get/jssdk', 'GET', [
             'query' => [
                 'media_id' => $mediaId,
             ],

--- a/tests/BasicService/QrCode/ClientTest.php
+++ b/tests/BasicService/QrCode/ClientTest.php
@@ -62,7 +62,7 @@ class ClientTest extends TestCase
         $client->makePartial();
 
         // temporary = true, expireSeconds = null
-        $client->expects()->httpPostJson('/cgi-bin/qrcode/create', [
+        $client->expects()->httpPostJson('cgi-bin/qrcode/create', [
             'action_name' => Client::SCENE_QR_CARD,
             'action_info' => ['scene' => ['foo' => 'bar']],
             'expire_seconds' => 7 * Client::DAY,
@@ -71,7 +71,7 @@ class ClientTest extends TestCase
         $this->assertSame('mock-result', $client->create(Client::SCENE_QR_CARD, ['foo' => 'bar']));
 
         // temporary = false, expireSeconds = null
-        $client->expects()->httpPostJson('/cgi-bin/qrcode/create', [
+        $client->expects()->httpPostJson('cgi-bin/qrcode/create', [
             'action_name' => Client::SCENE_QR_FOREVER,
             'action_info' => ['scene' => ['foo' => 'bar']],
         ])->andReturn('mock-result');
@@ -79,7 +79,7 @@ class ClientTest extends TestCase
         $this->assertSame('mock-result', $client->create(Client::SCENE_QR_FOREVER, ['foo' => 'bar'], false));
 
         // temporary = false, expireSeconds = 500
-        $client->expects()->httpPostJson('/cgi-bin/qrcode/create', [
+        $client->expects()->httpPostJson('cgi-bin/qrcode/create', [
             'action_name' => Client::SCENE_QR_TEMPORARY_STR,
             'action_info' => ['scene' => ['foo' => 'bar']],
             'expire_seconds' => 500,

--- a/tests/MiniProgram/OpenData/ClientTest.php
+++ b/tests/MiniProgram/OpenData/ClientTest.php
@@ -23,7 +23,7 @@ class ClientTest extends TestCase
         $data = [
             'key' => ['mock-key'],
         ];
-        $client->expects()->httpPostJson('/wxa/remove_user_storage', $data, [
+        $client->expects()->httpPostJson('wxa/remove_user_storage', $data, [
             'openid' => 'mock-openid',
             'sig_method' => 'hmac_sha256',
             'signature' => hash_hmac('sha256', json_encode($data), 'mock-session-key'),
@@ -48,7 +48,7 @@ class ClientTest extends TestCase
                 ],
             ],
         ];
-        $client->expects()->httpPostJson('/wxa/set_user_storage', $data, [
+        $client->expects()->httpPostJson('wxa/set_user_storage', $data, [
             'openid' => 'mock-openid',
             'sig_method' => 'hmac_sha256',
             'signature' => hash_hmac('sha256', json_encode($data), 'mock-session-key'),

--- a/tests/MiniProgram/PhoneNumber/ClientTest.php
+++ b/tests/MiniProgram/PhoneNumber/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
     {
         $client = $this->mockApiClient(Client::class);
 
-        $client->expects()->httpPostJson('/wxa/business/getuserphonenumber', [
+        $client->expects()->httpPostJson('wxa/business/getuserphonenumber', [
             'code' => 'test'
         ])->andReturn('mock-result');
 

--- a/tests/OfficialAccount/Card/JssdkClientTest.php
+++ b/tests/OfficialAccount/Card/JssdkClientTest.php
@@ -35,7 +35,7 @@ class JssdkClientTest extends TestCase
         $cache->expects()->has($cacheKey)->twice()->andReturns(false, true);
         $cache->expects()->get($cacheKey)->never();
         $cache->expects()->set($cacheKey, $ticket, $ticket['expires_in'] - 500);
-        $client->expects()->requestRaw('/cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'wx_card']])->andReturn($response);
+        $client->expects()->requestRaw('cgi-bin/ticket/getticket', 'GET', ['query' => ['type' => 'wx_card']])->andReturn($response);
 
         $this->assertSame($ticket, $client->getTicket());
     }


### PR DESCRIPTION
背景:
为了收敛内部微信调用，我们在内部构建了一个反向代理api.weixin.qq.com/qyapi.weixin.qq.com的服务。但是他是通过二级目录提供的
proxy-api.abc.com/api-weixin => api.weixin.qq.com
proxy-api.abc.com/qyapi-weixin => qyapi.weixin.qq.com

我们尝试在config中增加http.base_uri
~~~php 
$options = [
    'app_id'    => '',
    'secret'    => '',
    'token'     => 'easywechat',
    "http"=>[
        "base_uri"=>"http://127.0.0.1:8080/api-weixin/"
    ]
    // ...
];

$app = Factory::officialAccount($options);
~~~

但是发现由于guzzle拼接规则的限制。导致二级目录被拼接丢失。
<img width="905" alt="image" src="https://user-images.githubusercontent.com/7540584/147923453-2da13598-ec42-442e-a1fb-abcb70795eec.png">

所以根据guzzle的规则，支持base_uri设置二级目录
