### PR TITLE
[bugfix] pay 修复beta9 Message toString变更导致event_type为null的问题

### DIFF
--- a/src/Pay/Message.php
+++ b/src/Pay/Message.php
@@ -9,7 +9,7 @@ class Message extends \EasyWeChat\Kernel\Message
 {
     public function getOriginalAttributes(): array
     {
-        return json_decode((string) $this, true);
+        return json_decode($this->getOriginalContents(), true);
     }
 
     public function getEventType(): ?string

--- a/src/Pay/Server.php
+++ b/src/Pay/Server.php
@@ -88,7 +88,7 @@ class Server implements ServerInterface
             throw new RuntimeException('Invalid request.');
         }
 
-        $attributes = \json_decode(
+        $attributes = array_merge($attributes, \json_decode(
             AesGcm::decrypt(
                 $attributes['resource']['ciphertext'],
                 $this->merchant->getSecretKey(),
@@ -96,7 +96,7 @@ class Server implements ServerInterface
                 $attributes['resource']['associated_data'],
             ),
             true
-        );
+        ));
 
         return new Message($attributes, $originContent);
     }

--- a/src/Pay/Server.php
+++ b/src/Pay/Server.php
@@ -88,7 +88,7 @@ class Server implements ServerInterface
             throw new RuntimeException('Invalid request.');
         }
 
-        $attributes = array_merge($attributes, \json_decode(
+        $attributes = \json_decode(
             AesGcm::decrypt(
                 $attributes['resource']['ciphertext'],
                 $this->merchant->getSecretKey(),
@@ -96,7 +96,7 @@ class Server implements ServerInterface
                 $attributes['resource']['associated_data'],
             ),
             true
-        ));
+        );
 
         return new Message($attributes, $originContent);
     }


### PR DESCRIPTION
getEventType()依赖原来的getOriginalContents()方法，参考了其它的Server.php，发现不如直接把原来的数组merge在attributes返回更合理
<img width="1031" alt="image" src="https://user-images.githubusercontent.com/27892476/148401146-3b03a5a8-6a78-4ed1-bb2b-1faa2faec40b.png">
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/27892476/148401216-107bbd09-8c84-4e93-8050-728eb80c9dcf.png">
