### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "nyholm/psr7": "^1.4",
     "nyholm/psr7-server": "^1.0",
     "overtrue/socialite": "^3.5|^4.0",
-    "psr/simple-cache": "^1.0|^2.0",
+    "psr/simple-cache": "^1.0|^2.0|^3.0",
     "psr/http-client": "^1.0",
     "symfony/cache": "^5.4|^6.0",
     "symfony/http-foundation": "^5.4|^6.0",


### PR DESCRIPTION
```shell
$ composer why psr/simple-cache
laravel/framework  v9.0.0  requires  psr/simple-cache (^1.0|^2.0|^3.0)
```
