### PR TITLE
Fix `EasyWeChat\Kernel\Support\Collection::__serialize()/__unserialize()` type error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,4 +10,4 @@ phpstan.neon export-ignore
 phpunit.php export-ignore
 phpunit.xml export-ignore
 phpunit.xml.dist export-ignore
-.php_cs  export-ignore
+.php-cs-fixer.dist.php  export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,12 @@
 /vendor
 sftp-config.json
 /*.php
+!.php-cs-fixer.dist.php
 /.idea
 /coverage
 /.split
 /composer.lock
-.php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache
 cghooks.lock
 .vercel/

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,6 +1,6 @@
 <?php
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR2' => true,
         'binary_operator_spaces' => true,

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "ext-libxml": "*"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.15",
+    "friendsofphp/php-cs-fixer": "^3.5.0",
     "brainmaestro/composer-git-hooks": "^2.7",
     "mikey179/vfsstream": "^1.6",
     "mockery/mockery": "^1.2.3",
@@ -77,8 +77,8 @@
       "cghooks update"
     ],
     "phpstan": "vendor/bin/phpstan analyse",
-    "check-style": "vendor/bin/php-cs-fixer fix --using-cache=no --diff --config=.php_cs --dry-run --ansi",
-    "fix-style": "vendor/bin/php-cs-fixer fix --using-cache=no --config=.php_cs --ansi",
+    "check-style": "vendor/bin/php-cs-fixer fix --using-cache=no --diff --config=.php-cs-fixer.dist.php --dry-run --ansi",
+    "fix-style": "vendor/bin/php-cs-fixer fix --using-cache=no --config=.php-cs-fixer.dist.php --ansi",
     "test": "vendor/bin/phpunit --colors=always --testdox"
   }
 }

--- a/src/Kernel/Support/Collection.php
+++ b/src/Kernel/Support/Collection.php
@@ -235,17 +235,9 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate, JsonSeria
         return $this->items;
     }
 
-    /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
-     * String representation of object.
-     *
-     * @see http://php.net/manual/en/serializable.serialize.php
-     *
-     * @return string the string representation of the object or null
-     */
-    public function __serialize()
+    public function __serialize(): array
     {
-        return serialize($this->items);
+        return $this->items;
     }
 
     /**
@@ -293,23 +285,10 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate, JsonSeria
         return count($this->items);
     }
 
-    /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
-     * Constructs the object.
-     *
-     * @see  http://php.net/manual/en/serializable.unserialize.php
-     *
-     * @param string $serialized <p>
-     *                           The string representation of the object.
-     *                           </p>
-     *
-     * @return mixed|void
-     */
-    public function __unserialize($serialized)
+    public function __unserialize(array $data): void
     {
-        return $this->items = unserialize($serialized);
+        $this->items = $data;
     }
-
 
     /**
      * (PHP 5 &gt;= 5.1.0)<br/>

--- a/src/Work/Message/Client.php
+++ b/src/Work/Message/Client.php
@@ -12,7 +12,6 @@
 namespace EasyWeChat\Work\Message;
 
 use EasyWeChat\Kernel\BaseClient;
-use EasyWeChat\Kernel\Messages\Message;
 
 /**
  * Class Client.


### PR DESCRIPTION
Fixes: #2360

`__serialize()/__unserialize()`方法不能直接复用原有的`serialize()/unserialize()`，应当使用未经序列化/反序列化的数据。