### PR TITLE
新增微信物流服务退货组件相关接口

### DIFF
--- a/src/MiniProgram/Express/Client.php
+++ b/src/MiniProgram/Express/Client.php
@@ -37,6 +37,7 @@ class Client extends BaseClient
 
         return $this->httpPostJson('cgi-bin/express/business/account/bind', $params);
     }
+
     /**
      * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
      *
@@ -166,6 +167,43 @@ class Client extends BaseClient
         return $this->httpPostJson('cgi-bin/express/business/printer/update', [
             'update_type' => 'unbind',
             'openid' => $openid,
+        ]);
+    }
+
+    /**
+     * 创建退货 ID
+     * @param array $params
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     */
+    public function createReturn(array $params = [])
+    {
+        return $this->httpPostJson('cgi-bin/express/delivery/return/add', $params);
+    }
+
+    /**
+     * 查询退货 ID 状态
+     * @param string $returnId
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     */
+    public function getReturn(string $returnId)
+    {
+        return $this->httpPostJson('cgi-bin/express/delivery/return/get', [
+            'return_id' => $returnId
+        ]);
+    }
+
+    /**
+     * 解绑退货 ID
+     * @param string $returnId
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     */
+    public function unbindReturn(string $returnId)
+    {
+        return $this->httpPostJson('cgi-bin/express/delivery/return/unbind', [
+            'return_id' => $returnId
         ]);
     }
 }

--- a/tests/MiniProgram/Express/ClientTest.php
+++ b/tests/MiniProgram/Express/ClientTest.php
@@ -219,4 +219,70 @@ class ClientTest extends TestCase
 
         $this->assertSame('mock-result', $client->unbindPrinter('myopenid'));
     }
+
+    public function testCreateReturn()
+    {
+        $client = $this->mockApiClient(Client::class);
+
+        $data = [
+            'shop_order_id' => 'xxx',
+            'biz_addr' => [
+                'name' => '张三',
+                'mobile' => '13600000000',
+                'country' => '中国',
+                'province' => '广东省',
+                'city' => '广州市',
+                'area' => '海珠区',
+                'address' => 'xx路xx号'
+            ],
+            'user_addr' => [
+                'name' => '李四',
+                'mobile' => '13600000000',
+                'country' => '中国',
+                'province' => '广东省',
+                'city' => '广州市',
+                'area' => '海珠区',
+                'address' => 'xx路xx号'
+            ],
+            'openid' => 'xxx',
+            'order_path' => 'xxx',
+            'goods_list' => [
+                '0' => [
+                    'name' => 'xxx',
+                    'url' => 'xxx'
+                ]
+            ],
+            'order_price' => 1
+        ];
+
+        $client->expects()->httpPostJson('cgi-bin/express/delivery/return/add', $data)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->createReturn($data));
+    }
+
+    public function testGetReturn()
+    {
+        $client = $this->mockApiClient(Client::class);
+
+        $data = [
+            'return_id' => '1935761508265738242',
+        ];
+
+        $client->expects()->httpPostJson('cgi-bin/express/delivery/return/get', $data)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->getReturn('1935761508265738242'));
+    }
+
+    public function testUnbindReturn()
+    {
+        $client = $this->mockApiClient(Client::class);
+
+        $data = [
+            'return_id' => '1935761508265738242',
+        ];
+
+        $client->expects()->httpPostJson('cgi-bin/express/delivery/return/unbind', $data)->andReturn('mock-result');
+
+        $this->assertSame('mock-result', $client->unbindReturn('1935761508265738242'));
+    }
 }


### PR DESCRIPTION
微信物流服务退货组件相关接口， 具体文档在https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/industry/express/express_sale_return.html