### PR TITLE
Fix sample parameter error

### DIFF
--- a/docs/src/6.x/client.md
+++ b/docs/src/6.x/client.md
@@ -6,9 +6,11 @@
 $api = $app->getClient();
 
 $response = $api->post('/cgi-bin/user/info/updateremark', [
-    "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
-    "remark" => "pangzi"
-]);
+    'json' => [
+            "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
+            "remark" => "pangzi"
+        ]
+    ]);
 ```
 
 ## 语法说明
@@ -16,6 +18,7 @@ $response = $api->post('/cgi-bin/user/info/updateremark', [
 ```php
 get(string $uri, array $options = []): Symfony\Contracts\HttpClient\ResponseInterface
 post(string $uri, array $options = []): Symfony\Contracts\HttpClient\ResponseInterface
+postJson(string $url, array $options = []): Symfony\Contracts\HttpClient\ResponseInterface
 patch(string $uri, array $options = []): Symfony\Contracts\HttpClient\ResponseInterface
 put(string $uri, array $options = []): Symfony\Contracts\HttpClient\ResponseInterface
 delete(string $uri, array $options = []): Symfony\Contracts\HttpClient\ResponseInterface
@@ -51,7 +54,7 @@ $response = $api->post('/cgi-bin/user/info/updateremark', [
 或者可以简写为：
 
 ```php
-$response = $api->post('/cgi-bin/user/info/updateremark', [
+$response = $api->postJson('/cgi-bin/user/info/updateremark', [
         "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
         "remark" => "pangzi"
     ]);
@@ -225,7 +228,7 @@ $httpLogs = $response->getInfo('debug');
 
 ```php
 // 这段代码会立即执行，并不会发起网络请求
-$response = $api->post('/cgi-bin/user/info/updateremark', [
+$response = $api->postJson('/cgi-bin/user/info/updateremark', [
     "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
     "remark" => "pangzi"
 ]);

--- a/docs/src/6.x/client.md
+++ b/docs/src/6.x/client.md
@@ -225,10 +225,10 @@ $httpLogs = $response->getInfo('debug');
 
 ```php
 // 这段代码会立即执行，并不会发起网络请求
-$response = $api->post('/cgi-bin/user/info/updateremark', json_encode([
+$response = $api->post('/cgi-bin/user/info/updateremark', [
     "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
     "remark" => "pangzi"
-]));
+]);
 
 // 当你尝试访问 $response 的信息时，才会发起请求并等待返回
 $contentType = $response->getHeaders()['content-type'][0];

--- a/docs/src/6.x/client.md
+++ b/docs/src/6.x/client.md
@@ -5,10 +5,10 @@
 ```php
 $api = $app->getClient();
 
-$response = $api->post('/cgi-bin/user/info/updateremark', [
+$response = $api->post('/cgi-bin/user/info/updateremark', json_encode([
     "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
     "remark" => "pangzi"
-]);
+]));
 ```
 
 ## 语法说明
@@ -41,20 +41,20 @@ $response = $api->get('/cgi-bin/user/list'， [
 
 ```php
 $response = $api->post('/cgi-bin/user/info/updateremark', [
-    'body' => [
+    'body' => json_encode([
             "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
             "remark" => "pangzi"
-        ]
+        ])
     ]);
 ```
 
 或者可以简写为：
 
 ```php
-$response = $api->post('/cgi-bin/user/info/updateremark', [
+$response = $api->post('/cgi-bin/user/info/updateremark', json_encode([
         "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
         "remark" => "pangzi"
-    ]);
+    ]));
 ```
 
 或者指定 json 格式：
@@ -225,10 +225,10 @@ $httpLogs = $response->getInfo('debug');
 
 ```php
 // 这段代码会立即执行，并不会发起网络请求
-$response = $api->post('/cgi-bin/user/info/updateremark', [
+$response = $api->post('/cgi-bin/user/info/updateremark', json_encode([
     "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
     "remark" => "pangzi"
-])
+]));
 
 // 当你尝试访问 $response 的信息时，才会发起请求并等待返回
 $contentType = $response->getHeaders()['content-type'][0];

--- a/docs/src/6.x/client.md
+++ b/docs/src/6.x/client.md
@@ -5,10 +5,10 @@
 ```php
 $api = $app->getClient();
 
-$response = $api->post('/cgi-bin/user/info/updateremark', json_encode([
+$response = $api->post('/cgi-bin/user/info/updateremark', [
     "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
     "remark" => "pangzi"
-]));
+]);
 ```
 
 ## 语法说明
@@ -51,10 +51,10 @@ $response = $api->post('/cgi-bin/user/info/updateremark', [
 或者可以简写为：
 
 ```php
-$response = $api->post('/cgi-bin/user/info/updateremark', json_encode([
+$response = $api->post('/cgi-bin/user/info/updateremark', [
         "openid" => "oDF3iY9ffA-hqb2vVvbr7qxf6A0Q",
         "remark" => "pangzi"
-    ]));
+    ]);
 ```
 
 或者指定 json 格式：


### PR DESCRIPTION
修复json格式的接口，通过body传参的示例

----

~~省略body时应该是json格式；
以及使用body时也是传json，而不是数组，否则会报错~~
```
Symfony\Component\HttpClient\Exception\InvalidArgumentException: Unsupported option "openid" passed to "Symfony\Component\HttpClient\CurlHttpClient", did you mean "base_uri", "headers", "normalized_headers", "query", "auth_basic", "auth_bearer", "body", "json", "user_data", "max_redirects", "http_version", "buffer", "on_progress", "resolve", "proxy", "no_proxy", "timeout", "max_duration", "bindto", "verify_peer", "verify_host", "cafile", "capath", "local_cert", "local_pk", "passphrase", "ciphers", "peer_fingerprint", "capture_peer_cert_chain", "extra", "auth_ntlm"?
```