### PR TITLE
feat 增加企业微信服务商接口调用许可订单管理，账号管理接口

### DIFF
--- a/src/OpenWork/Application.php
+++ b/src/OpenWork/Application.php
@@ -28,6 +28,7 @@ use EasyWeChat\OpenWork\Work\Application as Work;
  * @property \EasyWeChat\OpenWork\MiniProgram\Client      $mini_program
  * @property \EasyWeChat\OpenWork\Media\Client            $media
  * @property \EasyWeChat\OpenWork\Contact\Client          $contact
+ * @property \EasyWeChat\OpenWork\License\Client          $license_order
  * @noinspection PhpFullyQualifiedNameUsageInspection
  */
 class Application extends ServiceContainer
@@ -44,6 +45,7 @@ class Application extends ServiceContainer
         MiniProgram\ServiceProvider::class,
         Media\ServiceProvider::class,
         Contact\ServiceProvider::class,
+        License\ServiceProvider::class,
     ];
 
     /**

--- a/src/OpenWork/Application.php
+++ b/src/OpenWork/Application.php
@@ -29,6 +29,7 @@ use EasyWeChat\OpenWork\Work\Application as Work;
  * @property \EasyWeChat\OpenWork\Media\Client            $media
  * @property \EasyWeChat\OpenWork\Contact\Client          $contact
  * @property \EasyWeChat\OpenWork\License\Client          $license_order
+ * @property \EasyWeChat\OpenWork\License\Account         $license_account
  * @noinspection PhpFullyQualifiedNameUsageInspection
  */
 class Application extends ServiceContainer

--- a/src/OpenWork/License/Account.php
+++ b/src/OpenWork/License/Account.php
@@ -1,0 +1,206 @@
+<?php
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\OpenWork\License;
+
+use EasyWeChat\Kernel\BaseClient;
+use EasyWeChat\Kernel\ServiceContainer;
+
+/**
+ * License Account Client
+ *
+ * @author moniang <me@imoniang.com>
+ */
+class Account extends BaseClient
+{
+    public function __construct(ServiceContainer $app)
+    {
+        parent::__construct($app, $app['provider_access_token']);
+    }
+
+    /**
+     * 激活帐号
+     *
+     * >下单购买帐号并支付完成之后，先调用{@see Client::getAccountList() 获取订单中的帐号列表}接口获取到帐号激活码，
+     * 然后可以调用该接口将激活码绑定到某个企业员工，以对其激活相应的平台服务能力。
+     *
+     * **一个userid允许激活一个基础帐号以及一个互通帐号。**
+     *
+     * @param string $activeCode 帐号激活码
+     * @param string $corpId     待绑定激活的成员所属企业corpId，只支持加密的corpId
+     * @param string $userId     待绑定激活的企业成员userId 。只支持加密的userId
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     * @noinspection SpellCheckingInspection
+     */
+    public function active(string $activeCode, string $corpId, string $userId)
+    {
+        return $this->httpPostJson('cgi-bin/license/active_account', [
+            'active_code' => $activeCode,
+            'corpid' => $corpId,
+            'userid' => $userId
+        ]);
+    }
+
+    /**
+     * 批量激活帐号
+     *
+     * >可在一次请求里为一个企业的多个成员激活许可帐号，便于服务商批量化处理。
+     *
+     * **一个userid允许激活一个基础帐号以及一个互通帐号。单次激活的员工数量不超过1000**
+     *
+     * @param string $corpId    待绑定激活的成员所属企业corpid，只支持加密的corpid
+     * @param array $activeList 需要激活的帐号列表,每个数组包含<b>active_code</b>帐号激活码和<b>userid</b>待绑定激活的企业成员加密userid
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     * @noinspection SpellCheckingInspection
+     */
+    public function batchActive(string $corpId, array $activeList)
+    {
+        return $this->httpPostJson('cgi-bin/license/batch_active_account', [
+            'corpid' => $corpId,
+            'active_list' => $activeList
+        ]);
+    }
+
+    /**
+     * 获取激活码详情
+     *
+     * >查询某个帐号激活码的状态以及激活绑定情况。
+     *
+     * @param string $corpId
+     * @param string $activeCode
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     * @noinspection SpellCheckingInspection
+     */
+    public function getActiveCodeInfo(string $corpId, string $activeCode)
+    {
+        return $this->httpPostJson('cgi-bin/license/get_active_info_by_code', [
+            'corpid' => $corpId,
+            'active_code' => $activeCode
+        ]);
+    }
+
+    /**
+     * 批量获取激活码详情
+     *
+     * >批量查询帐号激活码的状态以及激活绑定情况。
+     *
+     * @param string   $corpId         要查询的企业的corpid，只支持加密的corpid
+     * @param string[] $activeCodeList 激活码列表，最多不超过1000个
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     * @noinspection SpellCheckingInspection
+     */
+    public function batchGetActiveCodeInfo(string $corpId, array $activeCodeList)
+    {
+        return $this->httpPostJson('cgi-bin/license/batch_get_active_info_by_code', [
+            'corpid' => $corpId,
+            'active_code_list' => $activeCodeList
+        ]);
+    }
+
+    /**
+     * 获取企业的帐号列表
+     *
+     * >查询指定企业下的平台能力服务帐号列表。
+     *
+     * @param string      $corpId 企业corpId ，只支持加密的corpId
+     * @param string|null $cursor 返回的最大记录数，整型，最大值1000，默认值500
+     * @param int         $limit  用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     * @noinspection SpellCheckingInspection
+     */
+    public function list(string $corpId, ?string $cursor = null, int $limit = 500)
+    {
+        return $this->httpPostJson('cgi-bin/license/list_actived_account', [
+            'corpid' => $corpId,
+            'limit' => $limit,
+            'cursor' => $cursor
+        ]);
+    }
+
+    /**
+     * 获取成员的激活详情
+     *
+     * >查询某个企业成员的激活情况。
+     *
+     * @param string $corpId 企业corpId ，只支持加密的corpId
+     * @param string $userId 待查询员工的userid，只支持加密的userid
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     * @noinspection SpellCheckingInspection
+     */
+    public function getActiveAccountInfo(string $corpId, string $userId)
+    {
+        return $this->httpPostJson('cgi-bin/license/get_active_info_by_user', [
+            'corpid' => $corpId,
+            'userid' => $userId
+        ]);
+    }
+
+
+    /**
+     * 帐号继承
+     *
+     * >在企业员工离职或者工作范围的有变更时，允许将其许可帐号继承给其他员工。
+     *
+     * **调用限制:**
+     * - 转移成员和接收成员属于同一个企业
+     * - 转移成员的帐号已激活，且在有效期
+     * - 转移许可的成员为离职成员时，不限制下次转接的时间间隔
+     * - 转移许可的成员为在职成员时，转接后30天后才可进行下次转接
+     * - 接收成员许可不能与转移成员的许可重叠（同时拥有基础帐号或者互通帐号）
+     * - 单次转移的帐号数限制在1000以内
+     *
+     * @param string $corpId       待绑定激活的成员所属企业corpId，只支持加密的corpId
+     * @param array  $transferList 待转移成员列表，每个数组包含<b>handover_userid</b>转移成员的userid和<b>takeover_userid</b>接收成员的userid
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     * @noinspection SpellCheckingInspection
+     */
+    public function batchTransfer(string $corpId, array $transferList)
+    {
+        return $this->httpPostJson('cgi-bin/license/batch_transfer_license', [
+            'corpid' => $corpId,
+            'transfer_list' => $transferList
+        ]);
+    }
+}

--- a/src/OpenWork/License/Client.php
+++ b/src/OpenWork/License/Client.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace EasyWeChat\OpenWork\License;
+
+use EasyWeChat\Kernel\BaseClient;
+use EasyWeChat\Kernel\ServiceContainer;
+
+/**
+ * Order Client
+ *
+ * @author moniang <me@imoniang.com>
+ */
+class Client extends BaseClient
+{
+    public function __construct(ServiceContainer $app)
+    {
+        parent::__construct($app, $app['provider_access_token']);
+    }
+
+    /**
+     * 下单购买帐号
+     *
+     * 服务商下单为企业购买新的帐号，可以同时购买基础帐号与互通帐号。下单之后，需要到服务商管理端发起支付，支付完成之后，订单才能生效。
+     *
+     * @param string $corpId 企业id，只支持加密的corpid
+     * @param array $data
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection SpellCheckingInspection
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     */
+    public function create(string $corpId, array $data)
+    {
+        return $this->httpPostJson('cgi-bin/license/create_new_order', array_merge([
+            'corpid' => $corpId
+        ], $data));
+    }
+
+    /**
+     * 创建续期任务
+     *
+     * 在同一个订单里，首次创建任务无须指定jobid，后续指定同一个jobid，表示往同一个订单任务追加续期的成员。
+     *
+     * @param string $corpId 企业id，只支持加密的corpid
+     * @param array $data
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection SpellCheckingInspection
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     */
+    public function renew(string $corpId, array $data)
+    {
+        return $this->httpPostJson('cgi-bin/license/create_renew_order_job', array_merge([
+            'corpid' => $corpId
+        ], $data));
+    }
+
+    /**
+     * 提交续期订单
+     *
+     * 创建续期任务之后，需要调用该接口，以提交订单任务。注意，提交之后，需要到服务商管理端发起支付，支付完成之后，订单才能生效。
+     *
+     * @param string $jobId                 任务id
+     * @param string $buyerUserId           下单人。服务商企业内成员userid。该userid必须登录过企业微信，并且企业微信已绑定微信
+     * @param int    $accountDurationMonths 购买的月数，每个月按照31天计算。最多购买36个月。(若企业为服务商测试企业，每次续期只能续期1个月)
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection SpellCheckingInspection
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     */
+    public function submitJob(string $jobId, string $buyerUserId, int $accountDurationMonths)
+    {
+        return $this->httpPostJson('cgi-bin/license/submit_order_job', [
+            'jobid' => $jobId,
+            'buyer_userid' => $buyerUserId,
+            'account_duration' => [
+                'months' => $accountDurationMonths
+            ]
+        ]);
+    }
+
+    /**
+     * 获取订单列表
+     *
+     * 服务商查询自己某段时间内的平台能力服务订单列表
+     *
+     * @param string      $corpId     企业id，只支持加密的corpid。若指定corpid且corpid为服务商测试企业，则返回的订单列表为测试订单列表。否则只返回正式订单列表
+     * @param int|null    $startTime  开始时间,下单时间。可不填。但是不能单独指定该字段，startTime跟endTime必须同时指定。
+     * @param int|null    $endTime    结束时间,下单时间。起始时间跟结束时间不能超过31天。可不填。但是不能单独指定该字段，startTime跟endTime必须同时指定。
+     * @param string|null $cursor     用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
+     * @param int         $limit      返回的最大记录数，整型，最大值1000，默认值500
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection SpellCheckingInspection
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     */
+    public function list(string $corpId, ?int $startTime = null, ?int $endTime = null, ?string $cursor = null, int $limit = 500)
+    {
+        return $this->httpPostJson('cgi-bin/license/list_order', [
+            'corpid' => $corpId,
+            'start_time' => $startTime,
+            'end_time' => $endTime,
+            'cursor' => $cursor,
+            'limit' => $limit
+        ]);
+    }
+
+    /**
+     * 获取订单详情
+     *
+     * 查询某个订单的详情，包括订单的状态、基础帐号个数、互通帐号个数、帐号购买时长等。
+     * 注意，该接口不返回订单中的帐号激活码列表或者续期的帐号成员列表，请调用{@see Client::getAccountList() 获取订单中的帐号列表}接口以获取帐号列表。
+     *
+     * @param string $orderId 订单id
+     *
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection SpellCheckingInspection
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     */
+    public function get(string $orderId)
+    {
+        return $this->httpPostJson('cgi-bin/license/get_order', [
+            'order_id' => $orderId
+        ]);
+    }
+
+    /**
+     * 获取订单中的帐号列表
+     *
+     * 查询指定订单下的平台能力服务帐号列表。若为购买帐号的订单或者存量企业的版本付费迁移订单，则返回帐号激活码列表；
+     * 若为续期帐号的订单，则返回续期帐号的成员列表。
+     *
+     * 注意，若是购买帐号的订单，则仅订单支付完成时，系统才会生成帐号，故支付完成之前，该接口不会返回帐号激活码。
+     *
+     * @param string      $orderId 订单号
+     * @param string|null $cursor  用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
+     * @param int         $limit   返回的最大记录数，整型，最大值1000，默认值500
+     * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @noinspection SpellCheckingInspection
+     * @noinspection PhpFullyQualifiedNameUsageInspection
+     */
+    public function getAccountList(string $orderId, ?string $cursor = null, int $limit = 500)
+    {
+        return $this->httpPostJson('cgi-bin/license/list_order_account', [
+            'order_id' => $orderId,
+            'limit' => $limit,
+            'cursor' => $cursor
+        ]);
+    }
+}

--- a/src/OpenWork/License/Client.php
+++ b/src/OpenWork/License/Client.php
@@ -1,4 +1,12 @@
 <?php
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
 namespace EasyWeChat\OpenWork\License;
 

--- a/src/OpenWork/License/ServiceProvider.php
+++ b/src/OpenWork/License/ServiceProvider.php
@@ -29,5 +29,9 @@ class ServiceProvider implements ServiceProviderInterface
         !isset($app['license_order']) && $app['license_order'] = function ($app) {
             return new Client($app);
         };
+
+        !isset($app['license_account']) && $app['license_account'] = function ($app) {
+            return new Account($app);
+        };
     }
 }

--- a/src/OpenWork/License/ServiceProvider.php
+++ b/src/OpenWork/License/ServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the overtrue/wechat.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace EasyWeChat\OpenWork\License;
+
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+/**
+ * ServiceProvider.
+ *
+ * @author moniang <me@imoniang.com>
+ */
+class ServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * {@inheritdoc}.
+     */
+    public function register(Container $app)
+    {
+        !isset($app['license_order']) && $app['license_order'] = function ($app) {
+            return new Client($app);
+        };
+    }
+}


### PR DESCRIPTION
* 增加下单购买帐号接口
* 增加创建续期任务接口
* 增加提交续期订单接口
* 增加获取订单列表接口
* 增加获取订单详情接口
* 增加获取订单中的帐号列表接口
* 增加激活帐号接口
* 增加获取激活码详情接口
* 增加批量获取激活码详情接口
* 增加获取企业的帐号列表接口
* 增加获取成员的激活详情接口
* 增加帐号继承接口