### PR TITLE
4.x：修复日志功能在配置了 channels 后设置不生效的问题

### DIFF
--- a/src/Kernel/Providers/LogServiceProvider.php
+++ b/src/Kernel/Providers/LogServiceProvider.php
@@ -48,7 +48,9 @@ class LogServiceProvider implements ServiceProviderInterface
     public function formatLogConfig($app)
     {
         if (!empty($app['config']->get('log.channels'))) {
-            return $app['config']->get('log');
+            return [
+                'log' => $app['config']->get('log'),
+            ];
         }
 
         if (empty($app['config']->get('log'))) {


### PR DESCRIPTION
4.x 版本在日志设置中如果配置了 channels，原代码中直接返回了 `log` 的内容，导致 `$app['config']->merge($config)` 时被错误地合并到了 `config` 根节点下