### PR TITLE
scope=snsapi_privateinfo  时 agent_id 参数为必填项，否则会报错

### DIFF
--- a/src/Work/Application.php
+++ b/src/Work/Application.php
@@ -135,13 +135,14 @@ class Application implements ApplicationInterface
         ))->setPresets($this->config->all());
     }
 
-    public function getOAuth(): SocialiteProviderInterface
+    public function getOAuth($agent_id = ''): SocialiteProviderInterface
     {
         return (new WeWork(
             [
                 'client_id' => $this->getAccount()->getCorpId(),
                 'client_secret' => $this->getAccount()->getSecret(),
                 'redirect_url' => $this->config->get('oauth.redirect_url'),
+                'agent_id' => $agent_id,
             ]
         ))->withApiAccessToken($this->getAccessToken()->getToken())
             ->scopes((array) $this->config->get('oauth.scopes', ['snsapi_base']));


### PR DESCRIPTION
https://developer.work.weixin.qq.com/document/path/91022
scope=snsapi_privateinfo  时 agent_id 参数为必填项，否则会报错“agent_id is require when qrcode mode or scopes is 'snsapi_privateinfo'”