### PR TITLE
更新微信支付结果状态判断条件

### DIFF
--- a/src/Pay/Client.php
+++ b/src/Pay/Client.php
@@ -137,7 +137,12 @@ class Client implements HttpClientInterface
             $options['headers'] = array_merge($this->prependHeaders, $options['headers'] ?? []);
         }
 
-        return new Response($this->client->request($method, $url, $options), throw: $this->throw);
+        
+        return new Response(
+            $this->client->request($method, $url, $options), 
+            failureJudge: $this->isV3Request($url) ? null : fn (Response $response) => (bool) ($response->toArray()['result_code'] === 'FAIL' || $response->toArray()['return_code'] === 'FAIL'),
+            throw: $this->throw
+        );
     }
 
     protected function isV3Request(string $url): bool

--- a/src/Pay/Client.php
+++ b/src/Pay/Client.php
@@ -140,7 +140,7 @@ class Client implements HttpClientInterface
         
         return new Response(
             $this->client->request($method, $url, $options), 
-            failureJudge: $this->isV3Request($url) ? null : fn (Response $response) => (bool) ($response->toArray()['result_code'] === 'FAIL' || $response->toArray()['return_code'] === 'FAIL'),
+            failureJudge: $this->isV3Request($url) ? null : fn (Response $response) => $response->toArray()['result_code'] === 'FAIL' || $response->toArray()['return_code'] === 'FAIL',
             throw: $this->throw
         );
     }


### PR DESCRIPTION
修复微信支付（v2）版本接口 `$response->isSuccessful()` 方法无法按预期正确返回的问题。