### PR TITLE
增加getClient

### DIFF
--- a/src/Kernel/ServiceContainer.php
+++ b/src/Kernel/ServiceContainer.php
@@ -157,4 +157,8 @@ class ServiceContainer extends Container
             parent::register(new $provider());
         }
     }
+
+    public function getClient () {
+        return new BaseClient($this);
+    }
 }


### PR DESCRIPTION
更新内容:  增加getClient方法
更新说明:  老版本4.x有部分微信新的接口都未支持, 增加getClient后, 可以使用类似于6.x的方案, 用户可以通过client自行封装接口
举例: `$app->getClient()->httpPostJson('wxa/generate_urllink',$params);`

如果合并请求,后续这边再去提交完善一下4.x doc文档