### PR TITLE
修复uploadMedia 生成签名被下一步请求方法request()里面重新生成签名覆盖的问题

### DIFF
--- a/src/Pay/Client.php
+++ b/src/Pay/Client.php
@@ -137,7 +137,7 @@ class Client implements HttpClientInterface
 
         // 合并通过 withHeader 和 withHeaders 设置的信息
         if (! empty($this->prependHeaders)) {
-            $options['headers'] = array_merge($this->prependHeaders, $options['headers'] ?? []);
+            $options['headers'] = array_merge($options['headers'] ?? [], $this->prependHeaders);
         }
 
         return new Response(
@@ -194,9 +194,9 @@ class Client implements HttpClientInterface
 
         $signatureOptions['body'] = $meta;
 
-        $options['headers']['Authorization'] = $this->createSignature('POST', $uri, $signatureOptions);
-
-        return $this->request('POST', $uri, $options);
+        return $this->withHeaders([
+            'Authorization' => $this->createSignature('POST', $uri, $signatureOptions)
+        ])->request('POST', $uri, $options);
     }
 
     /**


### PR DESCRIPTION
request 请求 经过[, $options] = $this->prepareRequest($method, $url, $options, $this->defaultOptions, true);后 uploadMedia 生成签名被转成 [1] => Authorization: WECHATPAY2-SHA256-RSA2048 mchid="1634897681",nonce_str="Vke61UJhyrmABQVP",timestamp="1669617950",serial_no="134ECE1C4379C5FBAE2FD22B0F11E55A7AF7CB7A",signature="MdonK0gFk7zlYtLiR1jsiQJhz

request() 二次重新生成签名请求，导致了签名错误

修改uploadMedia方法 通过withHeaders方法传递Authorization
修改request方法 合并通过 withHeader 和 withHeaders 设置的信息的顺序 让自定义的 headers 覆盖自动生成的 headers