### PR TITLE
fix  MiniApp Application getAccessToken lost stable arguments

### DIFF
--- a/src/MiniApp/Application.php
+++ b/src/MiniApp/Application.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EasyWeChat\MiniApp;
 
-use function array_merge;
 use EasyWeChat\Kernel\Contracts\AccessToken as AccessTokenInterface;
 use EasyWeChat\Kernel\Contracts\Server as ServerInterface;
 use EasyWeChat\Kernel\Encryptor;
@@ -20,12 +19,14 @@ use EasyWeChat\Kernel\Traits\InteractWithHttpClient;
 use EasyWeChat\Kernel\Traits\InteractWithServerRequest;
 use EasyWeChat\MiniApp\Contracts\Account as AccountInterface;
 use EasyWeChat\MiniApp\Contracts\Application as ApplicationInterface;
-use function is_null;
 use JetBrains\PhpStorm\Pure;
 use Psr\Log\LoggerAwareTrait;
-use function str_contains;
 use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\HttpClient\RetryableHttpClient;
+
+use function array_merge;
+use function is_null;
+use function str_contains;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor
@@ -49,7 +50,7 @@ class Application implements ApplicationInterface
 
     public function getAccount(): AccountInterface
     {
-        if (! $this->account) {
+        if (!$this->account) {
             $this->account = new Account(
                 appId: (string) $this->config->get('app_id'), /** @phpstan-ignore-line */
                 secret: (string) $this->config->get('secret'), /** @phpstan-ignore-line */
@@ -73,7 +74,7 @@ class Application implements ApplicationInterface
      */
     public function getEncryptor(): Encryptor
     {
-        if (! $this->encryptor) {
+        if (!$this->encryptor) {
             $token = $this->getAccount()->getToken();
             $aesKey = $this->getAccount()->getAesKey();
 
@@ -106,7 +107,7 @@ class Application implements ApplicationInterface
      */
     public function getServer(): Server|ServerInterface
     {
-        if (! $this->server) {
+        if (!$this->server) {
             $this->server = new Server(
                 request: $this->getRequest(),
                 encryptor: $this->getAccount()->getAesKey() ? $this->getEncryptor() : null
@@ -125,12 +126,13 @@ class Application implements ApplicationInterface
 
     public function getAccessToken(): AccessTokenInterface
     {
-        if (! $this->accessToken) {
+        if (!$this->accessToken) {
             $this->accessToken = new AccessToken(
                 appId: $this->getAccount()->getAppId(),
                 secret: $this->getAccount()->getSecret(),
                 cache: $this->getCache(),
                 httpClient: $this->getHttpClient(),
+                stable: $this->config->get('use_stable_access_token', false)
             );
         }
 
@@ -167,7 +169,7 @@ class Application implements ApplicationInterface
             accessToken: $this->getAccessToken(),
             failureJudge: fn (
                 Response $response
-            ) => (bool) ($response->toArray()['errcode'] ?? 0) || ! is_null($response->toArray()['error'] ?? null),
+            ) => (bool) ($response->toArray()['errcode'] ?? 0) || !is_null($response->toArray()['error'] ?? null),
             throw: (bool) $this->config->get('http.throw', true),
         ))->setPresets($this->config->all());
     }
@@ -178,7 +180,7 @@ class Application implements ApplicationInterface
 
         return (new AccessTokenExpiredRetryStrategy($retryConfig))
             ->decideUsing(function (AsyncContext $context, ?string $responseContent): bool {
-                return ! empty($responseContent)
+                return !empty($responseContent)
                     && str_contains($responseContent, '42001')
                     && str_contains($responseContent, 'access_token expired');
             });


### PR DESCRIPTION
https://github.com/w7corp/easywechat/pull/2711 中，仅修改了公众号的StableAccessToken，小程序`Application`的`getAccessToken`并没有传递use_stable_access_token过去导致配置无效。