### PR TITLE
Update oauth.md

### DIFF
--- a/docs/src/5.x/official-account/oauth.md
+++ b/docs/src/5.x/official-account/oauth.md
@@ -176,10 +176,11 @@ $config = [
 
 $app = Factory::officialAccount($config);
 $oauth = $app->oauth;
-
 // 获取 OAuth 授权结果用户信息
 $code = "微信回调URL携带的 code";
-$user = $oauth->userFromCode($code);
+// 不少用户这里的 code 是来源于静默授权 如果这里你的 $oauth 没有配置 scopes 为 snsapi_base 调用 $oauth->userFromCode($code); 默认会走 snsapi_userinfo; 
+$oauth = $app->oauth->scopes(['snsapi_base'])
+$user = $oauth->userFromCode($code); 
 
 $_SESSION['wechat_user'] = $user->toArray();
 


### PR DESCRIPTION
scope 的配置说明，部分用户因为没有统一使用一个 $oauth 导致 。获取授权的 $oauth 配置了 scope ; 而获取 用户信息时未配置 scope 这个导致无法正确工作；这是由于用户粗心造成的，所以给文档添加了说明