### PR TITLE
【6.x】修复微信支付V2服务商分账接口验签失败的BUG

### DIFF
--- a/src/Pay/LegacySignature.php
+++ b/src/Pay/LegacySignature.php
@@ -55,9 +55,8 @@ class LegacySignature
             $signType = fn (string $message): string => hash_hmac('sha256', $message, $attributes['key']);
         } else {
             $signType = 'md5';
+            unset($params['sign_type']);
         }
-
-        unset($params['sign_type']);
 
         $sign = call_user_func_array($signType, [urldecode(http_build_query($attributes))]);
 

--- a/src/Pay/LegacySignature.php
+++ b/src/Pay/LegacySignature.php
@@ -55,7 +55,6 @@ class LegacySignature
             $signType = fn (string $message): string => hash_hmac('sha256', $message, $attributes['key']);
         } else {
             $signType = 'md5';
-            unset($params['sign_type']);
         }
 
         $sign = call_user_func_array($signType, [urldecode(http_build_query($attributes))]);


### PR DESCRIPTION
V2版本的分账要求签名类型必须为:`HMAC-SHA256`, 如果没有`sign_type`这个参数, 签名校验会失败.

[V2服务商分账接口文档](https://pay.weixin.qq.com/wiki/doc/api/allocation_sl.php?chapter=25_1&index=1)

![image](https://github.com/w7corp/easywechat/assets/16308633/1247b675-c4dc-492b-acfc-48973268bf27)

![image](https://github.com/w7corp/easywechat/assets/16308633/d5b8a4fc-3fa2-4e9b-915c-c276e3a19149)
