### PR TITLE
删除没使用到的依赖 symfony/psr-http-message-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "symfony/cache": "^3.3 || ^4.3 || ^5.0 || ^6.0",
     "symfony/event-dispatcher": "^4.3 || ^5.0 || ^6.0",
     "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-    "symfony/psr-http-message-bridge": "^0.3 || ^1.0 || ^2.0",
     "ext-libxml": "*"
   },
   "require-dev": {


### PR DESCRIPTION
我搜了下 5.x 的代码，这个依赖有引入但是没任何使用到的地方。
 Symfony这个包的版本号最近有很大变更，EasyWechat这边引用的版本太久了，导致其他地方必须要跟着降级。既然没用到不如直接删除这个依赖吧。