### PR TITLE
fix:修复值为0、'0'的参数会被过滤的问题

### DIFF
--- a/src/Pay/LegacySignature.php
+++ b/src/Pay/LegacySignature.php
@@ -38,9 +38,8 @@ class LegacySignature
                     'sub_appid' => $params['sub_appid'] ?? null,
                 ],
                 $params
-            ), function ($value) {
-                return $value !== '' && !is_null($value);
-            }
+            ),
+            static fn ($value, $key) => !($key === 'sign' || $value === '' || is_null($value))
         );
 
         ksort($attributes);

--- a/src/Pay/LegacySignature.php
+++ b/src/Pay/LegacySignature.php
@@ -38,7 +38,9 @@ class LegacySignature
                     'sub_appid' => $params['sub_appid'] ?? null,
                 ],
                 $params
-            )
+            ), function ($value) {
+                return $value !== '' && !is_null($value);
+            }
         );
 
         ksort($attributes);


### PR DESCRIPTION
v2版本有一些行业内接口，是需要传0的