### PR TITLE
fix:修复array_filter默认只传递值，回调报错的问题

### DIFF
--- a/src/Pay/LegacySignature.php
+++ b/src/Pay/LegacySignature.php
@@ -39,7 +39,8 @@ class LegacySignature
                 ],
                 $params
             ),
-            static fn ($value, $key) => !($key === 'sign' || $value === '' || is_null($value))
+            static fn ($value, $key) => !($key === 'sign' || $value === '' || is_null($value)),
+            ARRAY_FILTER_USE_BOTH
         );
 
         ksort($attributes);


### PR DESCRIPTION
如题