### PR TITLE
5.x 添加查询分账回退结果、发起自定义请求。安全请求自定义接口

### DIFF
--- a/src/Payment/ProfitSharing/Client.php
+++ b/src/Payment/ProfitSharing/Client.php
@@ -248,4 +248,32 @@ class Client extends BaseClient
             $params
         );
     }
+
+
+    /**
+     * 查询分账回退结果
+     *
+     * @param string $outOrderNo 商户订单号
+     * @param string $outReturnNo 分账回退单号
+     *
+     * @return array 查询结果数组
+     *
+     * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
+     * @throws \EasyWeChat\Kernel\Exceptions\RuntimeException
+     */
+    public function returnShareQuery(
+        string $outOrderNo,
+        string $outReturnNo
+    ) {
+        $params = [
+            'appid' => $this->app['config']->app_id,
+            'out_order_no' => $outOrderNo,
+            'out_return_no' => $outReturnNo,
+        ];
+
+        return $this->safeRequest(
+            'pay/profitsharingreturnquery',
+            $params
+        );
+    }
 }

--- a/src/Payment/ProfitSharing/Client.php
+++ b/src/Payment/ProfitSharing/Client.php
@@ -271,9 +271,56 @@ class Client extends BaseClient
             'out_return_no' => $outReturnNo,
         ];
 
-        return $this->safeRequest(
+        return $this->request(
             'pay/profitsharingreturnquery',
             $params
+        );
+    }
+
+    /**
+     * 发起自定义请求。
+     *
+     * @param string $url 请求的URL地址。
+     * @param array $params 请求参数数组。
+     * @return mixed 请求的结果。
+     */
+
+    public function requestCustom(
+        string $url,
+        array $params = [],
+        string $method = 'post',
+        array $options = [],
+        bool $returnResponse = false
+    ) {
+        return $this->request(
+            $url, 
+            $params,
+            $method,
+            $options,
+            $returnResponse
+        );
+    }
+    /**
+     * 安全请求自定义接口
+     *
+     * @param string $url 请求的URL地址
+     * @param array $params 请求参数数组
+     * @return mixed 返回请求的结果
+     *
+     * 该方法封装了一个安全的HTTP请求，用于向指定的URL发送请求并返回响应。
+     * 它内部调用了safeRequest方法，确保请求的安全性。
+     */
+    public function safeRequestCustom(
+        string $url,
+        array $params,
+        string $method = 'post',
+        array $options = []
+    ) {
+        return $this->safeRequest(
+            $url, 
+            $params,
+            $method,
+            $options
         );
     }
 }


### PR DESCRIPTION
分账回退的结果也是需要查询的，但是5.X的接口并未暴露对应的接口，因此本人完善了。
另外在payment里面考虑到还有一些其他的request和safeRequest的需求，我将client中的request和safeRequest两个接口暴露出来以方便调用。
请大佬帮忙发版，急用。
分账回退接口官方地址（V2）：https://pay.weixin.qq.com/wiki/doc/api/allocation.php?chapter=27_8&index=9