### PR TITLE
optim pay apiv2 specials, method signatures and `phpstan@^2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   "require-dev": {
     "mikey179/vfsstream": "^1.6",
     "mockery/mockery": "^1.4.4",
-    "phpstan/phpstan": "^1.0",
+    "phpstan/phpstan": "^1.0 | ^2",
     "phpunit/phpunit": "^9.5",
     "symfony/var-dumper": "^5.2",
     "jetbrains/phpstorm-attributes": "^1.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,12 @@ parameters:
         -
             identifier: missingType.iterableValue
         -
+            message: '#Property EasyWeChat\\Kernel\\Config::\$items \(array<string, mixed>\) does not accept array#'
+            path: src/Kernel/Config.php
+        -
+            message: '#Method EasyWeChat\\Kernel\\Message::format\(\) should return array<string, string> but returns array#'
+            path: src/Kernel/Message.php
+        -
             message: '#\$client .*? does not accept#'
             path: src/Kernel/HttpClient/AccessTokenAwareClient.php
         -
@@ -16,31 +22,34 @@ parameters:
             message: '#Parameter \#1 \$object of function spl_object_hash expects object, callable given#'
             path: src/Kernel/Traits/InteractWithHandlers.php
         -
-            message: '#Match arm is unreachable because previous comparison is always true#'
+            message: '#Call to function is_callable\(\) with callable\(\): mixed will always evaluate to true#'
             path: src/Kernel/Traits/InteractWithHandlers.php
         -
             message: '#Parameter \$stable of class EasyWeChat\\MiniApp\\AccessToken constructor expects bool\|null, mixed given#'
             path: src/MiniApp/Application.php
         -
-            message: '#Parameter \#1 \$options of static method EasyWeChat\\Kernel\\HttpClient\\RequestUtil::mergeDefaultRetryOptions\(\) expects array<string, mixed>, array given#'
+            message: '#Parameter \#1 \$options of static method EasyWeChat\\Kernel\\HttpClient\\RequestUtil::mergeDefaultRetryOptions\(\) expects array<string, mixed>#'
             path: src/MiniApp/Application.php
+        -
+            message: '#Method EasyWeChat\\MiniApp\\Decryptor::decrypt\(\) should return array<string, mixed> but returns array#'
+            path: src/MiniApp/Decryptor.php
         -
             message: '#Parameter \$stable of class EasyWeChat\\OfficialAccount\\(AccessToken|JsApiTicket) constructor expects bool\|null, mixed given#'
             path: src/OfficialAccount/Application.php
         -
-            message: '#Parameter \#1 \$options of static method EasyWeChat\\Kernel\\HttpClient\\RequestUtil::mergeDefaultRetryOptions\(\) expects array<string, mixed>, array given#'
+            message: '#Parameter \#1 \$options of static method EasyWeChat\\Kernel\\HttpClient\\RequestUtil::mergeDefaultRetryOptions\(\) expects array<string, mixed>#'
             path: src/OfficialAccount/Application.php
         -
-            message: '#Parameter \#1 \$scopes of method Overtrue\\Socialite\\Providers\\Base::scopes\(\) expects array<string>, array given#'
+            message: '#Parameter \#1 \$scopes of method Overtrue\\Socialite\\Providers\\Base::scopes\(\) expects array<string>#'
             path: src/OfficialAccount/Application.php
         -
-            message: '#Parameter \#1 \$scopes of method Overtrue\\Socialite\\Providers\\Base::scopes\(\) expects array<string>, array given#'
+            message: '#Parameter \#1 \$scopes of method Overtrue\\Socialite\\Providers\\Base::scopes\(\) expects array<string>#'
             path: src/OpenPlatform/Application.php
         -
-            message: '#Parameter \#1 \$scopes of method Overtrue\\Socialite\\Providers\\Base::scopes\(\) expects array<string>, array given#'
+            message: '#Parameter \#1 \$scopes of method Overtrue\\Socialite\\Providers\\Base::scopes\(\) expects array<string>#'
             path: src/OpenWork/Application.php
         -
-            message: '#Parameter \#3 \$defaultOptions of class EasyWeChat\\Pay\\Client constructor expects array<string, mixed>, array given#'
+            message: '#Parameter \#3 \$defaultOptions of class EasyWeChat\\Pay\\Client constructor expects array<string, mixed>#'
             path: src/Pay/Application.php
         -
             message: '#Property .*?\$client \(Symfony\\Contracts\\HttpClient\\HttpClientInterface\) does not accept Mockery\\Mock\|Symfony\\Contracts\\HttpClient\\HttpClientInterface#'
@@ -49,5 +58,8 @@ parameters:
             message: '#Method EasyWeChat\\Pay\\Client::createMockClient\(\) should return Mockery\\Mock\|Symfony\\Contracts\\HttpClient\\HttpClientInterface but returns Mockery\\LegacyMockInterface#'
             path: src/Pay/Client.php
         -
-            message: '#Parameter \#1 \$scopes of method Overtrue\\Socialite\\Providers\\Base::scopes\(\) expects array<string>, array given#'
+            message: '#Call to function is_string\(\) with string will always evaluate to true#'
+            path: src/Pay/Client.php
+        -
+            message: '#Parameter \#1 \$scopes of method Overtrue\\Socialite\\Providers\\Base::scopes\(\) expects array<string>#'
             path: src/Work/Application.php

--- a/src/Kernel/HttpClient/AccessTokenExpiredRetryStrategy.php
+++ b/src/Kernel/HttpClient/AccessTokenExpiredRetryStrategy.php
@@ -15,14 +15,14 @@ class AccessTokenExpiredRetryStrategy extends GenericRetryStrategy
 
     protected ?Closure $decider = null;
 
-    public function withAccessToken(AccessTokenInterface $accessToken): self
+    public function withAccessToken(AccessTokenInterface $accessToken): static
     {
         $this->accessToken = $accessToken;
 
         return $this;
     }
 
-    public function decideUsing(Closure $decider): self
+    public function decideUsing(Closure $decider): static
     {
         $this->decider = $decider;
 

--- a/src/Kernel/HttpClient/RequestUtil.php
+++ b/src/Kernel/HttpClient/RequestUtil.php
@@ -104,14 +104,14 @@ class RequestUtil
     }
 
     /**
-     * @param  array{headers?:array<string, string>, xml?:array|string, body?:array|string, json?:array|string}  $options
+     * @param  array{headers?:array<string, string>, xml?:mixed, body?:array|string, json?:mixed}  $options
      * @return array{headers?:array<string, string|array<string, string>|array<string>>, xml?:array|string, body?:array|string}
      */
     public static function formatBody(array $options): array
     {
         $contentType = $options['headers']['Content-Type'] ?? $options['headers']['content-type'] ?? null;
 
-        if (isset($options['xml'])) {
+        if (array_key_exists('xml', $options)) {
             if (is_array($options['xml'])) {
                 $options['xml'] = Xml::build($options['xml']);
             }
@@ -128,7 +128,7 @@ class RequestUtil
             unset($options['xml']);
         }
 
-        if (isset($options['json'])) {
+        if (array_key_exists('json', $options)) {
             if (is_array($options['json'])) {
                 /** XXX: 微信的 JSON 是比较奇葩的，比如菜单不能把中文 encode 为 unicode */
                 $options['json'] = json_encode(

--- a/src/Kernel/HttpClient/RequestWithPresets.php
+++ b/src/Kernel/HttpClient/RequestWithPresets.php
@@ -126,6 +126,9 @@ trait RequestWithPresets
         return $this;
     }
 
+    /**
+     * @return array{xml?:array<string,mixed>|string,json?:array<string,mixed>|string,body?:array<string,mixed>|string,query?:array<string,mixed>,headers?:array<string,string>}
+     */
     public function mergeThenResetPrepends(array $options, string $method = 'GET'): array
     {
         $name = in_array(strtoupper($method), ['GET', 'HEAD', 'DELETE']) ? 'query' : 'body';

--- a/src/Kernel/Support/Arr.php
+++ b/src/Kernel/Support/Arr.php
@@ -46,7 +46,7 @@ class Arr
 
     /**
      * @param  array<string|int, mixed>  $array
-     * @return array<string|int, mixed>
+     * @return array<string, mixed>
      */
     public static function set(array &$array, string|int|null $key, mixed $value): array
     {

--- a/src/Kernel/Support/PublicKey.php
+++ b/src/Kernel/Support/PublicKey.php
@@ -26,7 +26,7 @@ class PublicKey
     {
         $info = openssl_x509_parse($this->certificate);
 
-        if ($info === false || ! isset($info['serialNumberHex'])) {
+        if ($info === false) {
             throw new InvalidConfigException('Read the $certificate failed, please check it whether or nor correct');
         }
 

--- a/src/Kernel/Support/UserAgent.php
+++ b/src/Kernel/Support/UserAgent.php
@@ -9,6 +9,7 @@ use Composer\InstalledVersions;
 use function array_map;
 use function array_unshift;
 use function class_exists;
+use function constant;
 use function curl_version;
 use function defined;
 use function explode;
@@ -26,7 +27,7 @@ class UserAgent
         $value = array_map('strval', $appends);
 
         if (defined('HHVM_VERSION')) {
-            array_unshift($value, 'HHVM/'.HHVM_VERSION);
+            array_unshift($value, 'HHVM/'.constant('HHVM_VERSION'));
         }
 
         $disabledFunctions = explode(',', ini_get('disable_functions') ?: '');

--- a/src/Kernel/Traits/InteractWithHandlers.php
+++ b/src/Kernel/Traits/InteractWithHandlers.php
@@ -69,13 +69,13 @@ trait InteractWithHandlers
     /**
      * @throws InvalidArgumentException
      */
-    protected function getHandlerHash(callable|string $handler): string
+    protected function getHandlerHash(callable|array|string $handler): string
     {
         return match (true) {
             is_string($handler) => $handler,
-            is_array($handler) => is_string($handler[0]) ? $handler[0].'::'.$handler[1] : get_class(
-                $handler[0]
-            ).$handler[1],
+            is_array($handler) => is_string($handler[0])
+                ? $handler[0].'::'.$handler[1]
+                : get_class($handler[0]).$handler[1],
             $handler instanceof Closure => spl_object_hash($handler),
             is_callable($handler) => spl_object_hash($handler),
             default => throw new InvalidArgumentException('Invalid handler: '.gettype($handler)),

--- a/src/Kernel/Traits/InteractWithHttpClient.php
+++ b/src/Kernel/Traits/InteractWithHttpClient.php
@@ -8,11 +8,11 @@ use EasyWeChat\Kernel\HttpClient\RequestUtil;
 use EasyWeChat\Kernel\HttpClient\ScopingHttpClient;
 use EasyWeChat\Kernel\Support\Arr;
 use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 use function is_array;
-use function property_exists;
 
 trait InteractWithHttpClient
 {
@@ -32,8 +32,7 @@ trait InteractWithHttpClient
         $this->httpClient = $httpClient;
 
         if ($this instanceof LoggerAwareInterface && $httpClient instanceof LoggerAwareInterface
-            && property_exists($this, 'logger')
-            && $this->logger) {
+            && $this->logger instanceof LoggerInterface) {
             $httpClient->setLogger($this->logger);
         }
 

--- a/src/OfficialAccount/AccessToken.php
+++ b/src/OfficialAccount/AccessToken.php
@@ -77,7 +77,7 @@ class AccessToken implements RefreshableAccessTokenInterface
     }
 
     /**
-     * @return array<string, string>
+     * @return array{access_token:string}
      *
      * @throws HttpException
      * @throws InvalidArgumentException

--- a/src/Pay/Merchant.php
+++ b/src/Pay/Merchant.php
@@ -74,7 +74,7 @@ class Merchant implements MerchantInterface
     }
 
     /**
-     * @param  array<array-key, string|PublicKey>  $platformCerts
+     * @param  array<array-key, mixed>  $platformCerts
      * @return array<string, PublicKey>
      *
      * @throws InvalidArgumentException


### PR DESCRIPTION
优化 微信支付 `APIv2` 上的几个特例：

- 已知有5个`URL`传参是通过`GET`方式，兼容之；
- 已知通过微信支付商户平台/合作伙伴平台操作退款的，当前webhook通知为`XML`规范，严格校验通知头再处理；

支持 PHPStan v2；