### PR TITLE
optim the `pay` client and server on APIv2 specials, ref efedd21e

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,8 @@ name: Deploy
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the 6.x branch
+  # Triggers the workflow on push event but only for the 6.x branch(required the secrets environment)
   push:
-    branches: [ 6.x ]
-  pull_request:
     branches: [ 6.x ]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/tests/Pay/ClientTest.php
+++ b/tests/Pay/ClientTest.php
@@ -126,6 +126,23 @@ class ClientTest extends TestCase
         $this->assertSame(Xml::build(['foo' => 'bar']), $client->getRequestOptions()['body']);
     }
 
+    public function test_v2_request_appauth_getaccesstoken()
+    {
+        $client = Client::mock('{"retcode":-1,"access_token":"mock-token"}', 200, ['Content-Type' => 'application/json']);
+        $client->shouldReceive('createSignature')->never();
+        $client->shouldReceive('isV3Request')->andReturn(false);
+        $client->shouldReceive('attachLegacySignature')->with([
+            'foo' => 'bar',
+        ])->andReturn(['foo' => 'bar', 'sign' => 'mock-signature']);
+
+        $response = $client->get('/appauth/getaccesstoken', ['query' => ['foo' => 'bar']]);
+
+        $this->assertSame('GET', $client->getRequestMethod());
+        $this->assertEquals(['foo' => 'bar', 'sign' => 'mock-signature'], $client->getRequestOptions()['query']);
+        $this->assertSame('https://api.mch.weixin.qq.com/appauth/getaccesstoken?foo=bar&sign=mock-signature', $client->getRequestUrl());
+        $this->assertContains('Content-Type: text/xml', $client->getRequestOptions()['headers']);
+    }
+
     public function test_v3_upload_media()
     {
         $client = Client::mock();

--- a/tests/Pay/ServerTest.php
+++ b/tests/Pay/ServerTest.php
@@ -4,10 +4,22 @@ declare(strict_types=1);
 
 namespace EasyWeChat\Tests\Pay;
 
+use EasyWeChat\Kernel\Support\AesEcb;
+use EasyWeChat\Kernel\Support\AesGcm;
+use EasyWeChat\Kernel\Support\Xml;
 use EasyWeChat\Pay\Contracts\Merchant;
+use EasyWeChat\Pay\Message;
 use EasyWeChat\Pay\Server;
 use EasyWeChat\Tests\TestCase;
+use Mockery\LegacyMockInterface;
+use Nyholm\Psr7\Response;
 use Nyholm\Psr7\ServerRequest;
+use Psr\Http\Message\ResponseInterface;
+
+use function bin2hex;
+use function fopen;
+use function md5;
+use function random_bytes;
 
 class ServerTest extends TestCase
 {
@@ -16,10 +28,13 @@ class ServerTest extends TestCase
         $request = (new ServerRequest(
             'POST',
             'http://easywechat.com/',
-            [],
+            [
+                'Content-Type' => 'application/json',
+            ],
             fopen(__DIR__.'/../fixtures/files/pay_demo.json', 'r')
         ));
 
+        /** @var Merchant&LegacyMockInterface $merchant */
         $merchant = \Mockery::mock(Merchant::class);
         $merchant->shouldReceive('getSecretKey')->andReturn('key');
 
@@ -27,5 +42,107 @@ class ServerTest extends TestCase
 
         $response = $server->serve();
         $this->assertSame('{"code":"SUCCESS","message":"成功"}', \strval($response->getBody()));
+    }
+
+    public function test_legacy_encryped_by_aesecb_refund_request()
+    {
+        /** @var Merchant&LegacyMockInterface $merchant */
+        $merchant = \Mockery::mock(Merchant::class);
+        $merchant->shouldReceive(['getV2SecretKey' => random_bytes(32)]);
+        $symmtricKey = $merchant->getV2SecretKey();
+
+        $server = new Server($merchant, new ServerRequest(
+            'POST',
+            'http://easywechat.com/sample-webhook-handler',
+            [
+                'Content-Type' => 'text/xml',
+            ],
+            Xml::build([
+                'return_code' => 'SUCCESS',
+                'req_info' => AesEcb::encrypt(Xml::build([
+                    'refund_id' => '50000408942018111907145868882',
+                    'transaction_id' => '4200000215201811190261405420',
+                ]), md5($symmtricKey), ''),
+            ])
+        ));
+
+        $response = $server->with(function (Message $message): ResponseInterface {
+            $source = $message->getOriginalContents();
+            $parsed = $message->toArray();
+
+            $this->assertStringContainsString('<xml>', $source);
+            $this->assertStringContainsString('<req_info>', $source);
+            $this->assertStringNotContainsString('<refund_id>', $source);
+            $this->assertStringNotContainsString('<transaction_id>', $source);
+            $this->assertArrayNotHasKey('return_code', $parsed);
+            $this->assertArrayNotHasKey('req_info', $parsed);
+            $this->assertArrayHasKey('refund_id', $parsed);
+            $this->assertArrayHasKey('transaction_id', $parsed);
+
+            return new Response(
+                200,
+                ['Content-Type' => 'text/xml'],
+                '<xml><return_code>SUCCESS</return_code></xml>'
+            );
+        })->serve();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('<xml><return_code>SUCCESS</return_code></xml>', \strval($response->getBody()));
+    }
+
+    public function test_legacy_encryped_by_aesgcm_notification_request()
+    {
+        /** @var Merchant&LegacyMockInterface $merchant */
+        $merchant = \Mockery::mock(Merchant::class);
+        $merchant->shouldReceive(['getSecretKey' => random_bytes(32)]);
+        $symmtricKey = $merchant->getSecretKey();
+
+        $server = new Server($merchant, new ServerRequest(
+            'POST',
+            'http://easywechat.com/sample-webhook-handler',
+            [
+                'Content-Type' => 'text/xml',
+            ],
+            Xml::build([
+                'event_type' => 'TRANSACTION.SUCCESS',
+                'event_algorithm' => 'AEAD_AES_256_GCM',
+                'event_nonce' => $nonce = bin2hex(random_bytes(6)),
+                'event_associated_data' => $aad = '',
+                'event_ciphertext' => AesGcm::encrypt(Xml::build([
+                    'state' => 'USER_PAID',
+                    'service_id' => '1234352342',
+                ]), $symmtricKey, iv: $nonce, aad: $aad),
+            ])
+        ));
+
+        $response = $server->with(function (Message $message): ResponseInterface {
+            $source = $message->getOriginalContents();
+            $parsed = $message->toArray();
+
+            $this->assertStringContainsString('<xml>', $source);
+            $this->assertStringContainsString('<event_type>', $source);
+            $this->assertStringContainsString('<event_algorithm>', $source);
+            $this->assertStringContainsString('<event_nonce>', $source);
+            $this->assertStringContainsString('<event_associated_data>', $source);
+            $this->assertStringContainsString('<event_ciphertext>', $source);
+            $this->assertStringNotContainsString('<state>', $source);
+            $this->assertStringNotContainsString('<service_id>', $source);
+            $this->assertArrayHasKey('event_type', $parsed);
+            $this->assertArrayHasKey('event_algorithm', $parsed);
+            $this->assertArrayHasKey('event_nonce', $parsed);
+            $this->assertArrayHasKey('event_associated_data', $parsed);
+            $this->assertArrayHasKey('event_ciphertext', $parsed);
+            $this->assertArrayHasKey('state', $parsed);
+            $this->assertArrayHasKey('service_id', $parsed);
+
+            return new Response(
+                500,
+                ['Content-Type' => 'text/xml'],
+                '<xml><code>ERROR_NAME</code><message>ERROR_DESCRIPTION</message></xml>'
+            );
+        })->serve();
+
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame('<xml><code>ERROR_NAME</code><message>ERROR_DESCRIPTION</message></xml>', \strval($response->getBody()));
     }
 }


### PR DESCRIPTION
- 增加pay server对AesGcm加密内容的自动解密;
- 增加pay server测试用例示例 APIv2 上的`AesEcb`及`AecGcm`自动解密断言;