### PR TITLE
doc: fix vercel deploy

### DIFF
--- a/docs/src/6.x/work/examples.md
+++ b/docs/src/6.x/work/examples.md
@@ -4,7 +4,7 @@
 
 ## [被动回复](https://developer.work.weixin.qq.com/document/path/90241) {#server-mode}
 
-::: details 被动回复一个图片信息 {open .bg-transparent}
+::: details 被动回复一个图片信息 {open}
 
 ```php
 $server->with(function ($message) {


### PR DESCRIPTION
this bug https://github.com/vuejs/vitepress/pull/4128 was there a looooong time, it is blocked the vercel default deploy. hence go back without the custom-css-notation.