### PR TITLE
fix: 修复PHP8.4下隐式 nullable 参数声明弃用的问题(5.x)

### DIFF
--- a/src/BasicService/Jssdk/Client.php
+++ b/src/BasicService/Jssdk/Client.php
@@ -55,7 +55,7 @@ class Client extends BaseClient
      * @throws \Psr\SimpleCache\InvalidArgumentException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function buildConfig(array $jsApiList, bool $debug = false, bool $beta = false, bool $json = true, array $openTagList = [], string $url = null)
+    public function buildConfig(array $jsApiList, bool $debug = false, bool $beta = false, bool $json = true, array $openTagList = [], ?string $url = null)
     {
         $config = array_merge(compact('debug', 'beta', 'jsApiList', 'openTagList'), $this->configSignature($url));
 
@@ -78,7 +78,7 @@ class Client extends BaseClient
      * @throws \Psr\SimpleCache\InvalidArgumentException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function getConfigArray(array $apis, bool $debug = false, bool $beta = false, array $openTagList = [], string $url = null)
+    public function getConfigArray(array $apis, bool $debug = false, bool $beta = false, array $openTagList = [], ?string $url = null)
     {
         return $this->buildConfig($apis, $debug, $beta, false, $openTagList, $url);
     }
@@ -135,7 +135,7 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Psr\SimpleCache\InvalidArgumentException
      */
-    protected function configSignature(string $url = null, string $nonce = null, $timestamp = null): array
+    protected function configSignature(?string $url = null, ?string $nonce = null, $timestamp = null): array
     {
         $url = $url ?: $this->getUrl();
         $nonce = $nonce ?: Support\Str::quickRandom(10);

--- a/src/Kernel/BaseClient.php
+++ b/src/Kernel/BaseClient.php
@@ -50,7 +50,7 @@ class BaseClient
      * @param \EasyWeChat\Kernel\ServiceContainer                    $app
      * @param \EasyWeChat\Kernel\Contracts\AccessTokenInterface|null $accessToken
      */
-    public function __construct(ServiceContainer $app, AccessTokenInterface $accessToken = null)
+    public function __construct(ServiceContainer $app, ?AccessTokenInterface $accessToken = null)
     {
         $this->app = $app;
         $this->accessToken = $accessToken ?? $this->app['access_token'];
@@ -261,7 +261,7 @@ class BaseClient
             function (
                 $retries,
                 RequestInterface $request,
-                ResponseInterface $response = null
+                ?ResponseInterface $response = null
             ) {
                 // Limit the number of retries to 2
                 if ($retries < $this->app->config->get('http.max_retries', 1) && $response && $body = $response->getBody()) {

--- a/src/Kernel/Encryptor.php
+++ b/src/Kernel/Encryptor.php
@@ -70,7 +70,7 @@ class Encryptor
      * @param string|null $token
      * @param string|null $aesKey
      */
-    public function __construct(string $appId, string $token = null, string $aesKey = null)
+    public function __construct(string $appId, ?string $token = null, ?string $aesKey = null)
     {
         $this->appId = $appId;
         $this->token = $token;

--- a/src/Kernel/Exceptions/HttpException.php
+++ b/src/Kernel/Exceptions/HttpException.php
@@ -38,7 +38,7 @@ class HttpException extends Exception
      * @param null                                     $formattedResponse
      * @param int                                      $code
      */
-    public function __construct($message, ResponseInterface $response = null, $formattedResponse = null, $code = 0)
+    public function __construct($message, ?ResponseInterface $response = null, $formattedResponse = null, $code = 0)
     {
         parent::__construct($message, $code);
 

--- a/src/Kernel/Messages/Transfer.php
+++ b/src/Kernel/Messages/Transfer.php
@@ -40,7 +40,7 @@ class Transfer extends Message
      *
      * @param string|null $account
      */
-    public function __construct(string $account = null)
+    public function __construct(?string $account = null)
     {
         parent::__construct(compact('account'));
     }

--- a/src/Kernel/ServiceContainer.php
+++ b/src/Kernel/ServiceContainer.php
@@ -62,7 +62,7 @@ class ServiceContainer extends Container
      * @param array       $prepends
      * @param string|null $id
      */
-    public function __construct(array $config = [], array $prepends = [], string $id = null)
+    public function __construct(array $config = [], array $prepends = [], ?string $id = null)
     {
         $this->userConfig = $config;
 

--- a/src/Kernel/Support/Arr.php
+++ b/src/Kernel/Support/Arr.php
@@ -134,7 +134,7 @@ class Arr
      *
      * @return mixed
      */
-    public static function first(array $array, callable $callback = null, $default = null)
+    public static function first(array $array, ?callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
             if (empty($array)) {
@@ -164,7 +164,7 @@ class Arr
      *
      * @return mixed
      */
-    public static function last(array $array, callable $callback = null, $default = null)
+    public static function last(array $array, ?callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
             return empty($array) ? $default : end($array);
@@ -389,7 +389,7 @@ class Arr
      *
      * @throws \InvalidArgumentException
      */
-    public static function random(array $array, int $amount = null)
+    public static function random(array $array, ?int $amount = null)
     {
         if (is_null($amount)) {
             return $array[array_rand($array)];

--- a/src/Kernel/Traits/HasHttpRequests.php
+++ b/src/Kernel/Traits/HasHttpRequests.php
@@ -104,12 +104,12 @@ trait HasHttpRequests
     /**
      * Add a middleware.
      *
-     * @param callable $middleware
-     * @param string   $name
+     * @param callable    $middleware
+     * @param string|null $name
      *
      * @return $this
      */
-    public function pushMiddleware(callable $middleware, string $name = null)
+    public function pushMiddleware(callable $middleware, ?string $name = null)
     {
         if (!is_null($name)) {
             $this->middlewares[$name] = $middleware;

--- a/src/MiniProgram/AppCode/Client.php
+++ b/src/MiniProgram/AppCode/Client.php
@@ -63,7 +63,7 @@ class Client extends BaseClient
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      */
-    public function getQrCode(string $path, int $width = null)
+    public function getQrCode(string $path, ?int $width = null)
     {
         return $this->getStream('cgi-bin/wxaapp/createwxaqrcode', compact('path', 'width'));
     }

--- a/src/MiniProgram/SubscribeMessage/Client.php
+++ b/src/MiniProgram/SubscribeMessage/Client.php
@@ -123,7 +123,7 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function addTemplate(string $tid, array $kidList, string $sceneDesc = null)
+    public function addTemplate(string $tid, array $kidList, ?string $sceneDesc = null)
     {
         $sceneDesc = $sceneDesc ?? '';
         $data = \compact('tid', 'kidList', 'sceneDesc');

--- a/src/OfficialAccount/Card/CodeClient.php
+++ b/src/OfficialAccount/Card/CodeClient.php
@@ -159,7 +159,7 @@ class CodeClient extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function consume(string $code, string $cardId = null)
+    public function consume(string $code, ?string $cardId = null)
     {
         $params = [
             'code' => $code,

--- a/src/OfficialAccount/Comment/Client.php
+++ b/src/OfficialAccount/Comment/Client.php
@@ -31,7 +31,7 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function open(string $msgId, int $index = null)
+    public function open(string $msgId, ?int $index = null)
     {
         $params = [
             'msg_data_id' => $msgId,
@@ -52,7 +52,7 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function close(string $msgId, int $index = null)
+    public function close(string $msgId, ?int $index = null)
     {
         $params = [
             'msg_data_id' => $msgId,

--- a/src/OfficialAccount/Menu/Client.php
+++ b/src/OfficialAccount/Menu/Client.php
@@ -70,14 +70,14 @@ class Client extends BaseClient
     /**
      * Destroy menu.
      *
-     * @param int $menuId
+     * @param int|null $menuId
      *
      * @return mixed
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function delete(int $menuId = null)
+    public function delete(?int $menuId = null)
     {
         if (is_null($menuId)) {
             return $this->httpGet('cgi-bin/menu/delete');

--- a/src/OfficialAccount/SubscribeMessage/Client.php
+++ b/src/OfficialAccount/SubscribeMessage/Client.php
@@ -42,7 +42,7 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function addTemplate(string $tid, array $kidList, string $sceneDesc = null)
+    public function addTemplate(string $tid, array $kidList, ?string $sceneDesc = null)
     {
         $sceneDesc = $sceneDesc ?? '';
         $data = \compact('tid', 'kidList', 'sceneDesc');

--- a/src/OfficialAccount/User/UserClient.php
+++ b/src/OfficialAccount/User/UserClient.php
@@ -66,13 +66,13 @@ class UserClient extends BaseClient
     /**
      * List users.
      *
-     * @param string $nextOpenId
+     * @param string|null $nextOpenId
      *
      * @return \Psr\Http\Message\ResponseInterface|\EasyWeChat\Kernel\Support\Collection|array|object|string
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      */
-    public function list(string $nextOpenId = null)
+    public function list(?string $nextOpenId = null)
     {
         $params = ['next_openid' => $nextOpenId];
 
@@ -110,7 +110,7 @@ class UserClient extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function blacklist(string $beginOpenid = null)
+    public function blacklist(?string $beginOpenid = null)
     {
         $params = ['begin_openid' => $beginOpenid];
 

--- a/src/OfficialAccount/WiFi/ShopClient.php
+++ b/src/OfficialAccount/WiFi/ShopClient.php
@@ -85,7 +85,7 @@ class ShopClient extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function clearDevice(int $shopId, string $ssid = null)
+    public function clearDevice(int $shopId, ?string $ssid = null)
     {
         $data = [
             'shop_id' => $shopId,

--- a/src/OpenPlatform/Authorizer/MiniProgram/Code/Client.php
+++ b/src/OpenPlatform/Authorizer/MiniProgram/Code/Client.php
@@ -49,7 +49,7 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function getQrCode(string $path = null)
+    public function getQrCode(?string $path = null)
     {
         return $this->requestRaw('wxa/get_qrcode', 'GET', [
             'query' => ['path' => $path],
@@ -77,7 +77,7 @@ class Client extends BaseClient
     }
 
     /**
-     * @param array $data
+     * @param array       $data
      * @param string|null $feedbackInfo
      * @param string|null $feedbackStuff
      *
@@ -86,7 +86,7 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function submitAudit(array $data, string $feedbackInfo = null, string $feedbackStuff = null)
+    public function submitAudit(array $data, ?string $feedbackInfo = null, ?string $feedbackStuff = null)
     {
         if (isset($data['item_list'])) {
             return $this->httpPostJson('wxa/submit_audit', $data);

--- a/src/OpenPlatform/Authorizer/MiniProgram/Tester/Client.php
+++ b/src/OpenPlatform/Authorizer/MiniProgram/Tester/Client.php
@@ -40,15 +40,15 @@ class Client extends BaseClient
     /**
      * 解绑小程序体验者.
      *
-     * @param string $wechatId
-     * @param string $userStr
+     * @param string|null $wechatId
+     * @param string|null $userStr
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function unbind(string $wechatId = null, string $userStr = null)
+    public function unbind(?string $wechatId = null, ?string $userStr = null)
     {
         return $this->httpPostJson('wxa/unbind_tester', [
                 ($userStr ? 'userstr' : 'wechatid') => $userStr ?? $wechatId,

--- a/src/OpenPlatform/Base/Client.php
+++ b/src/OpenPlatform/Base/Client.php
@@ -30,7 +30,7 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function handleAuthorize(string $authCode = null)
+    public function handleAuthorize(?string $authCode = null)
     {
         $params = [
             'component_appid' => $this->app['config']['app_id'],

--- a/src/OpenPlatform/CodeTemplate/Client.php
+++ b/src/OpenPlatform/CodeTemplate/Client.php
@@ -57,14 +57,14 @@ class Client extends BaseClient
     /**
      * 获取代码模版库中的所有小程序代码模版.
      *
-     * @param int $templateType
+     * @param int|null $templateType
      *
      * @return mixed
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function list(int $templateType = null)
+    public function list(?int $templateType = null)
     {
         $params = [
             'template_type' => $templateType,

--- a/src/OpenWork/Contact/Client.php
+++ b/src/OpenWork/Contact/Client.php
@@ -37,7 +37,7 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @noinspection PhpFullyQualifiedNameUsageInspection
      */
-    public function idTranslate(string $authCorpId, array $mediaIdList, string $outputFileName = null, string $outputFileFormat = null)
+    public function idTranslate(string $authCorpId, array $mediaIdList, ?string $outputFileName = null, ?string $outputFileFormat = null)
     {
         /** @noinspection SpellCheckingInspection */
         return $this->httpPostJson('cgi-bin/service/contact/id_translate', [

--- a/src/OpenWork/Corp/Client.php
+++ b/src/OpenWork/Corp/Client.php
@@ -160,14 +160,14 @@ class Client extends BaseClient
     /**
      * 获取登录url.
      *
-     * @param string $redirectUri
-     * @param string $scope
+     * @param string      $redirectUri
+     * @param string      $scope
      * @param string|null $state
      *
      * @return string
      * @throws \Exception
      */
-    public function getOAuthRedirectUrl(string $redirectUri = '', string $scope = 'snsapi_userinfo', string $state = null)
+    public function getOAuthRedirectUrl(string $redirectUri = '', string $scope = 'snsapi_userinfo', ?string $state = null)
     {
         $redirectUri || $redirectUri = $this->app->config['redirect_uri_oauth'];
         $state || $state = random_bytes(64);

--- a/src/Payment/Application.php
+++ b/src/Payment/Application.php
@@ -155,7 +155,7 @@ class Application extends ServiceContainer
      *
      * @return $this
      */
-    public function setSubMerchant(string $mchId, string $appId = null)
+    public function setSubMerchant(string $mchId, ?string $appId = null)
     {
         $this['config']->set('sub_mch_id', $mchId);
         $this['config']->set('sub_appid', $appId);
@@ -178,7 +178,7 @@ class Application extends ServiceContainer
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidArgumentException
      */
-    public function getKey(string $endpoint = null)
+    public function getKey(?string $endpoint = null)
     {
         if ('sandboxnew/pay/getsignkey' === $endpoint) {
             return $this['config']->key;

--- a/src/Work/Auth/Client.php
+++ b/src/Work/Auth/Client.php
@@ -25,15 +25,15 @@ class Client extends BaseClient
      *
      * @see https://developer.work.weixin.qq.com/document/path/91022
      *
-     * @param string $redirectUri
-     * @param string $scope
-     * @param string $agentId
+     * @param string      $redirectUri
+     * @param string      $scope
+     * @param string      $agentId
      * @param string|null $state
      *
      * @return string
      * @throws \Exception
      */
-    public function getOAuthRedirectUrl(string $redirectUri = '', string $scope = 'snsapi_privateinfo', string $agentId = '', string $state = null)
+    public function getOAuthRedirectUrl(string $redirectUri = '', string $scope = 'snsapi_privateinfo', string $agentId = '', ?string $state = null)
     {
         $redirectUri || $redirectUri = $this->app->config['redirect_uri_oauth'];
         $state || $state = random_bytes(64);

--- a/src/Work/ExternalContact/ContactWayClient.php
+++ b/src/Work/ExternalContact/ContactWayClient.php
@@ -99,17 +99,17 @@ class ContactWayClient extends BaseClient
     /**
      * 获取企业已配置的「联系我」列表，注意，该接口仅可获取2021年7月10日以后创建的「联系我」
      *
-     * @param string $cursor 分页查询使用的游标，为上次请求返回的 next_cursor
-     * @param int $limit 每次查询的分页大小，默认为100条，最多支持1000条
+     * @param string   $cursor    分页查询使用的游标，为上次请求返回的 next_cursor
+     * @param int      $limit     每次查询的分页大小，默认为100条，最多支持1000条
      * @param int|null $startTime 「联系我」创建起始时间戳, 不传默认为90天前
-     * @param int|null $endTime 「联系我」创建结束时间戳, 不传默认为当前时间
+     * @param int|null $endTime   「联系我」创建结束时间戳, 不传默认为当前时间
      *
      * @return array|\EasyWeChat\Kernel\Support\Collection|object|\Psr\Http\Message\ResponseInterface|string
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function list(string $cursor = '', int $limit = 100, int $startTime = null, int $endTime = null)
+    public function list(string $cursor = '', int $limit = 100, ?int $startTime = null, ?int $endTime = null)
     {
         $data = [
             'cursor' => $cursor,

--- a/src/Work/Jssdk/Client.php
+++ b/src/Work/Jssdk/Client.php
@@ -24,7 +24,7 @@ use EasyWeChat\Kernel\Support;
  */
 class Client extends BaseClient
 {
-    public function __construct(ServiceContainer $app, AccessTokenInterface $accessToken = null)
+    public function __construct(ServiceContainer $app, ?AccessTokenInterface $accessToken = null)
     {
         parent::__construct($app, $accessToken);
 
@@ -42,12 +42,12 @@ class Client extends BaseClient
     /**
      * Return jsapi agent config as a PHP array.
      *
-     * @param  array  $apis
-     * @param  int|string  $agentId
-     * @param  bool  $debug
-     * @param  bool  $beta
-     * @param  array  $openTagList
-     * @param  string|null  $url
+     * @param  array      $apis
+     * @param  int|string $agentId
+     * @param  bool       $debug
+     * @param  bool       $beta
+     * @param  array      $openTagList
+     * @param string|null $url
      *
      * @return array|string
      *
@@ -63,7 +63,7 @@ class Client extends BaseClient
         bool $debug = false,
         bool $beta = false,
         array $openTagList = [],
-        string $url = null
+        ?string $url = null
     ) {
         return $this->buildAgentConfig($apis, $agentId, $debug, $beta, false, $openTagList, $url);
     }
@@ -71,13 +71,13 @@ class Client extends BaseClient
     /**
      * Get agent config json for jsapi.
      *
-     * @param  array  $jsApiList
-     * @param  int|string  $agentId
-     * @param  bool  $debug
-     * @param  bool  $beta
-     * @param  bool  $json
-     * @param  array  $openTagList
-     * @param  string|null  $url
+     * @param  array      $jsApiList
+     * @param  int|string $agentId
+     * @param  bool       $debug
+     * @param  bool       $beta
+     * @param  bool       $json
+     * @param  array      $openTagList
+     * @param string|null $url
      *
      * @return array|string
      *
@@ -94,7 +94,7 @@ class Client extends BaseClient
         bool $beta = false,
         bool $json = true,
         array $openTagList = [],
-        string $url = null
+        ?string $url = null
     ) {
         $config = array_merge(compact('debug', 'beta', 'jsApiList', 'openTagList'), $this->agentConfigSignature($agentId, $url));
 
@@ -102,10 +102,10 @@ class Client extends BaseClient
     }
 
     /**
-     * @param  int|string  $agentId
-     * @param  string|null  $url
-     * @param  string|null  $nonce
-     * @param  null  $timestamp
+     * @param  int|string $agentId
+     * @param string|null $url
+     * @param string|null $nonce
+     * @param  null       $timestamp
      *
      * @return array
      *
@@ -115,7 +115,7 @@ class Client extends BaseClient
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Psr\SimpleCache\InvalidArgumentException
      */
-    protected function agentConfigSignature($agentId, string $url = null, string $nonce = null, $timestamp = null): array
+    protected function agentConfigSignature($agentId, ?string $url = null, ?string $nonce = null, $timestamp = null): array
     {
         $url = $url ?: $this->getUrl();
         $nonce = $nonce ?: Support\Str::quickRandom(10);

--- a/src/Work/MsgAudit/Client.php
+++ b/src/Work/MsgAudit/Client.php
@@ -27,7 +27,7 @@ class Client extends BaseClient
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException|\GuzzleHttp\Exception\GuzzleException
      */
-    public function getPermitUsers(string $type = null)
+    public function getPermitUsers(?string $type = null)
     {
         return $this->httpPostJson('cgi-bin/msgaudit/get_permit_user_list', (empty($type) ? [] : ['type' => $type]));
     }

--- a/src/Work/OA/Client.php
+++ b/src/Work/OA/Client.php
@@ -291,16 +291,16 @@ class Client extends BaseClient
     /**
      * Get Approval Data.
      *
-     * @param int $startTime
-     * @param int $endTime
-     * @param int $nextNumber
+     * @param int      $startTime
+     * @param int      $endTime
+     * @param int|null $nextNumber
      *
      * @return mixed
      *
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function approvalRecords(int $startTime, int $endTime, int $nextNumber = null)
+    public function approvalRecords(int $startTime, int $endTime, ?int $nextNumber = null)
     {
         $params = [
             'starttime' => $startTime,

--- a/src/Work/User/Client.php
+++ b/src/Work/User/Client.php
@@ -151,7 +151,7 @@ class Client extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function userIdToOpenid(string $userId, int $agentId = null)
+    public function userIdToOpenid(string $userId, ?int $agentId = null)
     {
         $params = [
             'userid' => $userId,

--- a/src/Work/User/TagClient.php
+++ b/src/Work/User/TagClient.php
@@ -31,7 +31,7 @@ class TagClient extends BaseClient
      * @throws \EasyWeChat\Kernel\Exceptions\InvalidConfigException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function create(string $tagName, int $tagId = null)
+    public function create(string $tagName, ?int $tagId = null)
     {
         $params = [
             'tagname' => $tagName,

--- a/tests/Kernel/BaseClientTest.php
+++ b/tests/Kernel/BaseClientTest.php
@@ -23,7 +23,7 @@ use Monolog\Logger;
 
 class BaseClientTest extends TestCase
 {
-    public function makeClient($methods = [], ServiceContainer $app = null, AccessToken $accessToken = null)
+    public function makeClient($methods = [], ?ServiceContainer $app = null, ?AccessToken $accessToken = null)
     {
         $methods = !empty($methods) ? \sprintf('[%s]', implode(',', (array) $methods)) : '';
         $app = $app ?? \Mockery::mock(ServiceContainer::class);

--- a/tests/Kernel/Traits/ObservableTest.php
+++ b/tests/Kernel/Traits/ObservableTest.php
@@ -370,7 +370,7 @@ class DummyClassForObservableTest
     use Observable;
     protected $app;
 
-    public function __construct(ServiceContainer $app = null)
+    public function __construct(?ServiceContainer $app = null)
     {
         $this->app = $app;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,7 +32,7 @@ class TestCase extends BaseTestCase
      *
      * @return \Mockery\Mock
      */
-    public function mockApiClient($name, $methods = [], ServiceContainer $app = null)
+    public function mockApiClient($name, $methods = [], ?ServiceContainer $app = null)
     {
         $methods = implode(',', array_merge([
             'httpGet', 'httpPost', 'httpPostJson', 'httpUpload',


### PR DESCRIPTION
在PHP8.4下隐式 nullable 参数声明会导致弃用警告：`Implicitly marking parameter $token as nullable is deprecated, the explicit nullable type must be used instead`